### PR TITLE
Use local client for fake data in tests

### DIFF
--- a/.run/go test unit.run.xml
+++ b/.run/go test unit.run.xml
@@ -2,7 +2,7 @@
   <configuration default="false" name="go test unit" type="GoTestRunConfiguration" factoryName="Go Test">
     <module name="grafeas-elasticsearch" />
     <working_directory value="$PROJECT_DIR$" />
-    <go_parameters value="-i -short" />
+    <go_parameters value="-i -short -count 1" />
     <framework value="gotest" />
     <kind value="DIRECTORY" />
     <package value="github.com/rode/grafeas-elasticsearch" />

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.15
 
 require (
 	github.com/Jeffail/gabs/v2 v2.6.0
-	github.com/brianvoe/gofakeit/v5 v5.10.1
+	github.com/brianvoe/gofakeit/v6 v6.0.0
 	github.com/elastic/go-elasticsearch/v7 v7.5.1-0.20201104130636-152864b47d96
 	github.com/golang/mock v1.4.4
 	github.com/golang/protobuf v1.4.2
@@ -23,6 +23,7 @@ require (
 	golang.org/x/sys v0.0.0-20201118182958-a01c418693c7 // indirect
 	google.golang.org/genproto v0.0.0-20200806141610-86f49bd18e98
 	google.golang.org/grpc v1.33.1
+	google.golang.org/grpc/examples v0.0.0-20210111180913-4cf4a98505bc // indirect
 	google.golang.org/protobuf v1.25.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -33,8 +33,8 @@ github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kB
 github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJmJgSg28kpZDP6UIiPt0e0Oz0kqKNGyRaWEPv84=
 github.com/boltdb/bolt v1.3.1 h1:JQmyP4ZBrce+ZQu0dY660FMfatumYDLun9hBCUVIkF4=
 github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=
-github.com/brianvoe/gofakeit/v5 v5.10.1 h1:XamPDOAIoxcjEaeE+B4VvRsXk/g5OXm4gReH2fJCxNU=
-github.com/brianvoe/gofakeit/v5 v5.10.1/go.mod h1:/ZENnKqX+XrN8SORLe/fu5lZDIo1tuPncWuRD+eyhSI=
+github.com/brianvoe/gofakeit/v6 v6.0.0 h1:3T2WNkEakjqZQEC52ciHNlDVyNA5m2dzUXAwdBVHgPU=
+github.com/brianvoe/gofakeit/v6 v6.0.0/go.mod h1:palrJUk4Fyw38zIFB/uBZqsgzW5VsNllhHKKwAebzew=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
@@ -437,8 +437,8 @@ google.golang.org/grpc v1.27.1/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8
 google.golang.org/grpc v1.31.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
 google.golang.org/grpc v1.33.1 h1:DGeFlSan2f+WEtCERJ4J9GJWk15TxUi8QGagfI87Xyc=
 google.golang.org/grpc v1.33.1/go.mod h1:fr5YgcSWrqhRRxogOsw7RzIpsmvOZ6IcH4kBYTpR3n0=
-google.golang.org/grpc/examples v0.0.0-20201211171407-c638ab8ccda6 h1:EZ0hz95G65YQYAisUeZxwyPAKnBJGCzC9rj/AZysDOs=
-google.golang.org/grpc/examples v0.0.0-20201211171407-c638ab8ccda6/go.mod h1:Ly7ZA/ARzg8fnPU9TyZIxoz33sEUuWX7txiqs8lPTgE=
+google.golang.org/grpc/examples v0.0.0-20210111180913-4cf4a98505bc h1:gTOEWVlti14M6g1P2rbiJVPKIdIS9XbaIj/nbcNezA8=
+google.golang.org/grpc/examples v0.0.0-20210111180913-4cf4a98505bc/go.mod h1:Ly7ZA/ARzg8fnPU9TyZIxoz33sEUuWX7txiqs8lPTgE=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=

--- a/go/config/config_suite_test.go
+++ b/go/config/config_suite_test.go
@@ -1,16 +1,16 @@
 package config
 
 import (
-	"github.com/brianvoe/gofakeit/v5"
+	"github.com/brianvoe/gofakeit/v6"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
-func TestConfig(t *testing.T) {
-	gofakeit.Seed(0)
+var fake = gofakeit.New(0)
 
+func TestConfig(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Config Suite")
 }

--- a/go/config/config_test.go
+++ b/go/config/config_test.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"github.com/brianvoe/gofakeit/v5"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
@@ -11,6 +10,8 @@ var _ = Describe("ElasticsearchConfig", func() {
 	DescribeTable("validation", func(c ElasticsearchConfig, shouldErr bool) {
 		err := c.IsValid()
 
+		println(c.URL)
+
 		if shouldErr {
 			Expect(err).To(HaveOccurred())
 		} else {
@@ -18,19 +19,19 @@ var _ = Describe("ElasticsearchConfig", func() {
 		}
 	},
 		Entry("valid url, refresh true", ElasticsearchConfig{
-			URL:     gofakeit.URL(),
+			URL:     fake.URL(),
 			Refresh: RefreshTrue,
 		}, false),
 		Entry("valid url, refresh wait_for", ElasticsearchConfig{
-			URL:     gofakeit.URL(),
+			URL:     fake.URL(),
 			Refresh: RefreshWaitFor,
 		}, false),
 		Entry("valid url, refresh false", ElasticsearchConfig{
-			URL:     gofakeit.URL(),
+			URL:     fake.URL(),
 			Refresh: RefreshFalse,
 		}, false),
 		Entry("valid url, invalid refresh option", ElasticsearchConfig{
-			URL:     gofakeit.URL(),
+			URL:     fake.URL(),
 			Refresh: "somethingInvalid",
 		}, true),
 	)

--- a/go/config/config_test.go
+++ b/go/config/config_test.go
@@ -10,8 +10,6 @@ var _ = Describe("ElasticsearchConfig", func() {
 	DescribeTable("validation", func(c ElasticsearchConfig, shouldErr bool) {
 		err := c.IsValid()
 
-		println(c.URL)
-
 		if shouldErr {
 			Expect(err).To(HaveOccurred())
 		} else {

--- a/go/v1beta1/storage/elasticsearch_test.go
+++ b/go/v1beta1/storage/elasticsearch_test.go
@@ -23,7 +23,6 @@ import (
 	prpb "github.com/grafeas/grafeas/proto/v1beta1/project_go_proto"
 
 	"github.com/Jeffail/gabs/v2"
-	"github.com/brianvoe/gofakeit/v5"
 	"github.com/elastic/go-elasticsearch/v7"
 	"github.com/elastic/go-elasticsearch/v7/esapi"
 	"github.com/grafeas/grafeas/proto/v1beta1/common_go_proto"
@@ -45,7 +44,7 @@ var _ = Describe("elasticsearch storage", func() {
 	)
 
 	BeforeEach(func() {
-		expectedProjectId = gofakeit.LetterN(10)
+		expectedProjectId = fake.LetterN(10)
 
 		ctx = context.Background()
 
@@ -53,7 +52,7 @@ var _ = Describe("elasticsearch storage", func() {
 		filterer = mocks.NewMockFilterer(mockCtrl)
 		transport = &mockEsTransport{}
 		esConfig = &config.ElasticsearchConfig{
-			URL:     gofakeit.URL(),
+			URL:     fake.URL(),
 			Refresh: config.RefreshTrue,
 		}
 	})
@@ -88,7 +87,7 @@ var _ = Describe("elasticsearch storage", func() {
 				{
 					StatusCode: http.StatusOK,
 					Body: structToJsonBody(&esIndexDocResponse{
-						Id: gofakeit.LetterN(10),
+						Id: fake.LetterN(10),
 					}),
 				},
 				{
@@ -121,7 +120,7 @@ var _ = Describe("elasticsearch storage", func() {
 			BeforeEach(func() {
 				transport.preparedHttpResponses[0] = &http.Response{
 					StatusCode: http.StatusOK,
-					Body:       createEsSearchResponse("project", gofakeit.LetterN(10)),
+					Body:       createEsSearchResponse("project", fake.LetterN(10)),
 				}
 			})
 
@@ -249,7 +248,7 @@ var _ = Describe("elasticsearch storage", func() {
 			expectedQuery = &filtering.Query{}
 			expectedFilter = ""
 			expectedProjectIndex = fmt.Sprintf("%s-%s", indexPrefix, "projects")
-			expectedProjects = generateTestProjects(gofakeit.Number(2, 5))
+			expectedProjects = generateTestProjects(fake.Number(2, 5))
 			transport.preparedHttpResponses = []*http.Response{
 				{
 					StatusCode: http.StatusOK,
@@ -281,10 +280,10 @@ var _ = Describe("elasticsearch storage", func() {
 			BeforeEach(func() {
 				expectedQuery = &filtering.Query{
 					Term: &filtering.Term{
-						gofakeit.LetterN(10): gofakeit.LetterN(10),
+						fake.LetterN(10): fake.LetterN(10),
 					},
 				}
-				expectedFilter = gofakeit.LetterN(10)
+				expectedFilter = fake.LetterN(10)
 
 				filterer.
 					EXPECT().
@@ -308,12 +307,12 @@ var _ = Describe("elasticsearch storage", func() {
 
 		When("an invalid filter is specified", func() {
 			BeforeEach(func() {
-				expectedFilter = gofakeit.LetterN(10)
+				expectedFilter = fake.LetterN(10)
 
 				filterer.
 					EXPECT().
 					ParseExpression(expectedFilter).
-					Return(nil, errors.New(gofakeit.LetterN(10)))
+					Return(nil, errors.New(fake.LetterN(10)))
 			})
 
 			It("should not send a request to elasticsearch", func() {
@@ -455,7 +454,7 @@ var _ = Describe("elasticsearch storage", func() {
 				transport.preparedHttpResponses = []*http.Response{
 					{
 						StatusCode: http.StatusOK,
-						Body:       ioutil.NopCloser(strings.NewReader(gofakeit.LetterN(10))),
+						Body:       ioutil.NopCloser(strings.NewReader(fake.LetterN(10))),
 					},
 				}
 			})
@@ -624,7 +623,7 @@ var _ = Describe("elasticsearch storage", func() {
 		)
 
 		BeforeEach(func() {
-			expectedOccurrenceId = gofakeit.LetterN(10)
+			expectedOccurrenceId = fake.LetterN(10)
 			expectedOccurrenceIndex = fmt.Sprintf("%s-%s-occurrences", indexPrefix, expectedProjectId)
 			expectedOccurrenceName = fmt.Sprintf("projects/%s/occurrences/%s", expectedProjectId, expectedOccurrenceId)
 			transport.preparedHttpResponses = []*http.Response{
@@ -688,7 +687,7 @@ var _ = Describe("elasticsearch storage", func() {
 				transport.preparedHttpResponses = []*http.Response{
 					{
 						StatusCode: http.StatusOK,
-						Body:       ioutil.NopCloser(strings.NewReader(gofakeit.LetterN(10))),
+						Body:       ioutil.NopCloser(strings.NewReader(fake.LetterN(10))),
 					},
 				}
 			})
@@ -725,7 +724,7 @@ var _ = Describe("elasticsearch storage", func() {
 		// BeforeEach configures the happy path for this context
 		// Variables configured here may be overridden in nested BeforeEach blocks
 		BeforeEach(func() {
-			expectedOccurrenceESId = gofakeit.LetterN(10)
+			expectedOccurrenceESId = fake.LetterN(10)
 			expectedOccurrencesIndex = fmt.Sprintf("%s-%s-occurrences", indexPrefix, expectedProjectId)
 			expectedOccurrence = generateTestOccurrence("")
 
@@ -799,8 +798,8 @@ var _ = Describe("elasticsearch storage", func() {
 					StatusCode: http.StatusInternalServerError,
 					Body: structToJsonBody(&esIndexDocResponse{
 						Error: &esIndexDocError{
-							Type:   gofakeit.LetterN(10),
-							Reason: gofakeit.LetterN(10),
+							Type:   fake.LetterN(10),
+							Reason: fake.LetterN(10),
 						},
 					}),
 				}
@@ -835,7 +834,7 @@ var _ = Describe("elasticsearch storage", func() {
 		// Variables configured here may be overridden in nested BeforeEach blocks
 		BeforeEach(func() {
 			expectedOccurrencesIndex = fmt.Sprintf("%s-%s-%s", indexPrefix, expectedProjectId, "occurrences")
-			expectedOccurrences = generateTestOccurrences(gofakeit.Number(2, 5))
+			expectedOccurrences = generateTestOccurrences(fake.Number(2, 5))
 			for i := 0; i < len(expectedOccurrences); i++ {
 				expectedErrs = append(expectedErrs, nil)
 			}
@@ -938,7 +937,7 @@ var _ = Describe("elasticsearch storage", func() {
 			var randomErrorIndex int
 
 			BeforeEach(func() {
-				randomErrorIndex = gofakeit.Number(0, len(expectedOccurrences)-1)
+				randomErrorIndex = fake.Number(0, len(expectedOccurrences)-1)
 				expectedErrs = []error{}
 				for i := 0; i < len(expectedOccurrences); i++ {
 					if i == randomErrorIndex {
@@ -978,7 +977,7 @@ var _ = Describe("elasticsearch storage", func() {
 		)
 
 		BeforeEach(func() {
-			expectedOccurrenceId = gofakeit.LetterN(10)
+			expectedOccurrenceId = fake.LetterN(10)
 			expectedOccurrencesIndex = fmt.Sprintf("%s-%s-occurrences", indexPrefix, expectedProjectId)
 			expectedOccurrenceName = fmt.Sprintf("projects/%s/occurrences/%s", expectedProjectId, expectedOccurrenceId)
 
@@ -1093,7 +1092,7 @@ var _ = Describe("elasticsearch storage", func() {
 			expectedQuery = &filtering.Query{}
 			expectedFilter = ""
 			expectedOccurrencesIndex = fmt.Sprintf("%s-%s-occurrences", indexPrefix, expectedProjectId)
-			expectedOccurrences = generateTestOccurrences(gofakeit.Number(2, 5))
+			expectedOccurrences = generateTestOccurrences(fake.Number(2, 5))
 			transport.preparedHttpResponses = []*http.Response{
 				{
 					StatusCode: http.StatusOK,
@@ -1125,10 +1124,10 @@ var _ = Describe("elasticsearch storage", func() {
 			BeforeEach(func() {
 				expectedQuery = &filtering.Query{
 					Term: &filtering.Term{
-						gofakeit.LetterN(10): gofakeit.LetterN(10),
+						fake.LetterN(10): fake.LetterN(10),
 					},
 				}
-				expectedFilter = gofakeit.LetterN(10)
+				expectedFilter = fake.LetterN(10)
 
 				filterer.
 					EXPECT().
@@ -1152,12 +1151,12 @@ var _ = Describe("elasticsearch storage", func() {
 
 		When("an invalid filter is specified", func() {
 			BeforeEach(func() {
-				expectedFilter = gofakeit.LetterN(10)
+				expectedFilter = fake.LetterN(10)
 
 				filterer.
 					EXPECT().
 					ParseExpression(expectedFilter).
-					Return(nil, errors.New(gofakeit.LetterN(10)))
+					Return(nil, errors.New(fake.LetterN(10)))
 			})
 
 			It("should not send a request to elasticsearch", func() {
@@ -1245,11 +1244,11 @@ var _ = Describe("elasticsearch storage", func() {
 		BeforeEach(func() {
 			// this setup is a bit different when compared to the tests for creating occurrences
 			// grafeas requires that the user specify a note's ID (and thus its name) beforehand
-			expectedNoteId = gofakeit.LetterN(10)
+			expectedNoteId = fake.LetterN(10)
 			expectedNoteName = fmt.Sprintf("projects/%s/notes/%s", expectedProjectId, expectedNoteId)
 			expectedNotesIndex = fmt.Sprintf("%s-%s-notes", indexPrefix, expectedProjectId)
 			expectedNote = generateTestNote(expectedNoteName)
-			expectedNoteESId = gofakeit.LetterN(10)
+			expectedNoteESId = fake.LetterN(10)
 
 			transport.preparedHttpResponses = []*http.Response{
 				{
@@ -1308,8 +1307,8 @@ var _ = Describe("elasticsearch storage", func() {
 						StatusCode: http.StatusInternalServerError,
 						Body: structToJsonBody(&esIndexDocResponse{
 							Error: &esIndexDocError{
-								Type:   gofakeit.LetterN(10),
-								Reason: gofakeit.LetterN(10),
+								Type:   fake.LetterN(10),
+								Reason: fake.LetterN(10),
 							},
 						}),
 					}
@@ -1420,7 +1419,7 @@ var _ = Describe("elasticsearch storage", func() {
 		// Variables configured here may be overridden in nested BeforeEach blocks
 		BeforeEach(func() {
 			expectedNotesIndex = fmt.Sprintf("%s-%s-notes", indexPrefix, expectedProjectId)
-			expectedNotes = generateTestNotes(gofakeit.Number(2, 5), expectedProjectId)
+			expectedNotes = generateTestNotes(fake.Number(2, 5), expectedProjectId)
 			expectedNotesWithNoteIds = convertSliceOfNotesToMap(expectedNotes)
 
 			// happy path: none of the provided notes exist, all of the provided notes were created successfully
@@ -1565,7 +1564,7 @@ var _ = Describe("elasticsearch storage", func() {
 		)
 
 		BeforeEach(func() {
-			expectedNoteId = gofakeit.LetterN(10)
+			expectedNoteId = fake.LetterN(10)
 			expectedNotesIndex = fmt.Sprintf("%s-%s-notes", indexPrefix, expectedProjectId)
 			expectedNoteName = fmt.Sprintf("projects/%s/notes/%s", expectedProjectId, expectedNoteId)
 			transport.preparedHttpResponses = []*http.Response{
@@ -1629,7 +1628,7 @@ var _ = Describe("elasticsearch storage", func() {
 				transport.preparedHttpResponses = []*http.Response{
 					{
 						StatusCode: http.StatusOK,
-						Body:       ioutil.NopCloser(strings.NewReader(gofakeit.LetterN(10))),
+						Body:       ioutil.NopCloser(strings.NewReader(fake.LetterN(10))),
 					},
 				}
 			})
@@ -1668,7 +1667,7 @@ var _ = Describe("elasticsearch storage", func() {
 			expectedQuery = &filtering.Query{}
 			expectedFilter = ""
 			expectedNotesIndex = fmt.Sprintf("%s-%s-notes", indexPrefix, expectedProjectId)
-			expectedNotes = generateTestNotes(gofakeit.Number(2, 5), expectedProjectId)
+			expectedNotes = generateTestNotes(fake.Number(2, 5), expectedProjectId)
 			transport.preparedHttpResponses = []*http.Response{
 				{
 					StatusCode: http.StatusOK,
@@ -1700,10 +1699,10 @@ var _ = Describe("elasticsearch storage", func() {
 			BeforeEach(func() {
 				expectedQuery = &filtering.Query{
 					Term: &filtering.Term{
-						gofakeit.LetterN(10): gofakeit.LetterN(10),
+						fake.LetterN(10): fake.LetterN(10),
 					},
 				}
-				expectedFilter = gofakeit.LetterN(10)
+				expectedFilter = fake.LetterN(10)
 
 				filterer.
 					EXPECT().
@@ -1727,12 +1726,12 @@ var _ = Describe("elasticsearch storage", func() {
 
 		When("an invalid filter is specified", func() {
 			BeforeEach(func() {
-				expectedFilter = gofakeit.LetterN(10)
+				expectedFilter = fake.LetterN(10)
 
 				filterer.
 					EXPECT().
 					ParseExpression(expectedFilter).
-					Return(nil, errors.New(gofakeit.LetterN(10)))
+					Return(nil, errors.New(fake.LetterN(10)))
 			})
 
 			It("should not send a request to elasticsearch", func() {
@@ -1813,7 +1812,7 @@ var _ = Describe("elasticsearch storage", func() {
 		)
 
 		BeforeEach(func() {
-			expectedNoteId = gofakeit.LetterN(10)
+			expectedNoteId = fake.LetterN(10)
 			expectedNotesIndex = fmt.Sprintf("%s-%s-notes", indexPrefix, expectedProjectId)
 			expectedNoteName = fmt.Sprintf("projects/%s/notes/%s", expectedProjectId, expectedNoteId)
 
@@ -1955,7 +1954,7 @@ func createGenericEsSearchResponse(messages ...proto.Message) io.ReadCloser {
 	}
 
 	response := &esSearchResponse{
-		Took: gofakeit.Number(1, 10),
+		Took: fake.Number(1, 10),
 		Hits: &esSearchResponseHits{
 			Total: &esSearchResponseTotal{
 				Value: len(hits),
@@ -1996,7 +1995,7 @@ func createEsSearchResponse(objectType string, hitNames ...string) io.ReadCloser
 	}
 
 	response := &esSearchResponse{
-		Took: gofakeit.Number(1, 10),
+		Took: fake.Number(1, 10),
 		Hits: &esSearchResponseHits{
 			Total: &esSearchResponseTotal{
 				Value: len(hitNames),
@@ -2022,8 +2021,8 @@ func createEsBulkOccurrenceIndexResponse(occurrences []*pb.Occurrence, errs []er
 		)
 		if errs[i] != nil {
 			responseErr = &esIndexDocError{
-				Type:   gofakeit.LetterN(10),
-				Reason: gofakeit.LetterN(10),
+				Type:   fake.LetterN(10),
+				Reason: fake.LetterN(10),
 			}
 			responseCode = http.StatusInternalServerError
 			responseHasErrors = true
@@ -2031,7 +2030,7 @@ func createEsBulkOccurrenceIndexResponse(occurrences []*pb.Occurrence, errs []er
 
 		responseItems = append(responseItems, &esBulkResponseItem{
 			Index: &esIndexDocResponse{
-				Id:     gofakeit.LetterN(10),
+				Id:     fake.LetterN(10),
 				Status: responseCode,
 				Error:  responseErr,
 			},
@@ -2054,7 +2053,7 @@ func createEsBulkNoteIndexResponse(notesThatCreatedSuccessfully map[string]*pb.N
 	for range notesThatCreatedSuccessfully {
 		responseItems = append(responseItems, &esBulkResponseItem{
 			Index: &esIndexDocResponse{
-				Id:     gofakeit.LetterN(10),
+				Id:     fake.LetterN(10),
 				Status: http.StatusCreated,
 			},
 		})
@@ -2099,7 +2098,7 @@ func generateTestProject(name string) *prpb.Project {
 func generateTestProjects(l int) []*prpb.Project {
 	var result []*prpb.Project
 	for i := 0; i < l; i++ {
-		result = append(result, generateTestProject(gofakeit.LetterN(10)))
+		result = append(result, generateTestProject(fake.LetterN(10)))
 	}
 
 	return result
@@ -2109,11 +2108,11 @@ func generateTestOccurrence(name string) *pb.Occurrence {
 	return &pb.Occurrence{
 		Name: name,
 		Resource: &grafeas_go_proto.Resource{
-			Uri: gofakeit.LetterN(10),
+			Uri: fake.LetterN(10),
 		},
-		NoteName:    gofakeit.LetterN(10),
+		NoteName:    fake.LetterN(10),
 		Kind:        common_go_proto.NoteKind_NOTE_KIND_UNSPECIFIED,
-		Remediation: gofakeit.LetterN(10),
+		Remediation: fake.LetterN(10),
 		Details:     nil,
 		CreateTime:  ptypes.TimestampNow(),
 	}
@@ -2131,8 +2130,8 @@ func generateTestOccurrences(l int) []*pb.Occurrence {
 func generateTestNote(name string) *pb.Note {
 	return &pb.Note{
 		Name:             name,
-		ShortDescription: gofakeit.Phrase(),
-		LongDescription:  gofakeit.Phrase(),
+		ShortDescription: fake.Phrase(),
+		LongDescription:  fake.Phrase(),
 		Kind:             common_go_proto.NoteKind_NOTE_KIND_UNSPECIFIED,
 		CreateTime:       ptypes.TimestampNow(),
 	}
@@ -2141,7 +2140,7 @@ func generateTestNote(name string) *pb.Note {
 func generateTestNotes(l int, project string) []*pb.Note {
 	var result []*pb.Note
 	for i := 0; i < l; i++ {
-		result = append(result, generateTestNote(fmt.Sprintf("projects/%s/notes/%s", project, gofakeit.LetterN(10))))
+		result = append(result, generateTestNote(fmt.Sprintf("projects/%s/notes/%s", project, fake.LetterN(10))))
 	}
 
 	return result

--- a/go/v1beta1/storage/grafeas_test.go
+++ b/go/v1beta1/storage/grafeas_test.go
@@ -2,7 +2,6 @@ package storage
 
 import (
 	"fmt"
-	"github.com/brianvoe/gofakeit/v5"
 	"github.com/elastic/go-elasticsearch/v7"
 	"github.com/elastic/go-elasticsearch/v7/esapi"
 	"github.com/golang/mock/gomock"
@@ -29,7 +28,7 @@ var _ = Describe("Grafeas integration", func() {
 		filterer = mocks.NewMockFilterer(mockCtrl)
 		transport = &mockEsTransport{}
 		esConfig = &config.ElasticsearchConfig{
-			URL:     gofakeit.URL(),
+			URL:     fake.URL(),
 			Refresh: config.RefreshTrue,
 		}
 	})

--- a/go/v1beta1/storage/storage_suite_test.go
+++ b/go/v1beta1/storage/storage_suite_test.go
@@ -1,7 +1,7 @@
 package storage
 
 import (
-	"github.com/brianvoe/gofakeit/v5"
+	"github.com/brianvoe/gofakeit/v6"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"go.uber.org/zap"
@@ -9,18 +9,13 @@ import (
 	"testing"
 )
 
-var logger *zap.Logger
+var logger = zap.NewNop()
+var fake = gofakeit.New(0)
 
 func TestStoragePackage(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Storage Suite")
 }
-
-var _ = BeforeSuite(func() {
-	logger = zap.NewNop()
-
-	gofakeit.Seed(0)
-})
 
 type mockEsTransport struct {
 	receivedHttpRequests  []*http.Request

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -3,15 +3,16 @@ package util
 import (
 	"context"
 	"fmt"
-	fake "github.com/brianvoe/gofakeit/v5"
+	"github.com/brianvoe/gofakeit/v6"
 	"github.com/grafeas/grafeas/proto/v1beta1/grafeas_go_proto"
 	"github.com/grafeas/grafeas/proto/v1beta1/project_go_proto"
 	. "github.com/onsi/gomega"
 	"google.golang.org/grpc"
 	"log"
 	"testing"
-	"time"
 )
+
+var fake = gofakeit.New(0)
 
 type Setup struct {
 	Ctx context.Context
@@ -64,8 +65,4 @@ func CreateProject(s *Setup, n string) (*project_go_proto.Project, error) {
 
 func RandomNoteName(project string) string {
 	return fmt.Sprintf("%s/notes/%s", project, fake.UUID())
-}
-
-func init() {
-	fake.Seed(time.Now().UnixNano())
 }

--- a/test/v1beta1/main_test.go
+++ b/test/v1beta1/main_test.go
@@ -2,11 +2,13 @@ package v1beta1_test
 
 import (
 	"flag"
-	fake "github.com/brianvoe/gofakeit/v5"
+	"github.com/brianvoe/gofakeit/v6"
 	"log"
 	"os"
 	"testing"
 )
+
+var fake = gofakeit.New(0)
 
 func TestMain(m *testing.M) {
 	flag.Parse()
@@ -15,8 +17,6 @@ func TestMain(m *testing.M) {
 		log.Println("Test run with -short flag, skipping integration.")
 		os.Exit(0)
 	}
-
-	fake.Seed(0)
 
 	os.Exit(m.Run())
 }

--- a/test/v1beta1/note_test.go
+++ b/test/v1beta1/note_test.go
@@ -2,7 +2,6 @@ package v1beta1_test
 
 import (
 	"fmt"
-	fake "github.com/brianvoe/gofakeit/v5"
 	"github.com/grafeas/grafeas/proto/v1beta1/attestation_go_proto"
 	"github.com/grafeas/grafeas/proto/v1beta1/build_go_proto"
 	"github.com/grafeas/grafeas/proto/v1beta1/common_go_proto"
@@ -18,6 +17,7 @@ import (
 )
 
 func TestNote(t *testing.T) {
+
 	Expect := util.NewExpect(t)
 	s := util.NewSetup()
 

--- a/test/v1beta1/occurrence_test.go
+++ b/test/v1beta1/occurrence_test.go
@@ -2,7 +2,6 @@ package v1beta1_test
 
 import (
 	"fmt"
-	fake "github.com/brianvoe/gofakeit/v5"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/grafeas/grafeas/proto/v1beta1/attestation_go_proto"
 	"github.com/grafeas/grafeas/proto/v1beta1/build_go_proto"


### PR DESCRIPTION
This resolves the issue of changing/relying on global random seed for fake data in tests.

Creating the faker clients as package vars, to simplify reuse and helper function signatures.