### PR TITLE
Expose Elasticsearch types for reuse

### DIFF
--- a/go/v1beta1/storage/elasticsearch.go
+++ b/go/v1beta1/storage/elasticsearch.go
@@ -53,7 +53,7 @@ func (es *ElasticsearchStorage) CreateProject(ctx context.Context, projectId str
 	log := es.logger.Named("CreateProject").With(zap.String("project", projectName))
 
 	// check if project already exists
-	search := &esSearch{
+	search := &EsSearch{
 		Query: &filtering.Query{
 			Term: &filtering.Term{
 				"name": projectName,
@@ -104,7 +104,7 @@ func (es *ElasticsearchStorage) GetProject(ctx context.Context, projectId string
 	projectName := fmt.Sprintf("projects/%s", projectId)
 	log := es.logger.Named("GetProject").With(zap.String("project", projectName))
 
-	search := &esSearch{
+	search := &EsSearch{
 		Query: &filtering.Query{
 			Term: &filtering.Term{
 				"name": projectName,
@@ -157,7 +157,7 @@ func (es *ElasticsearchStorage) DeleteProject(ctx context.Context, projectId str
 	log := es.logger.Named("DeleteProject").With(zap.String("project", projectName))
 	log.Debug("deleting project")
 
-	search := &esSearch{
+	search := &EsSearch{
 		Query: &filtering.Query{
 			Term: &filtering.Term{
 				"name": projectName,
@@ -193,7 +193,7 @@ func (es *ElasticsearchStorage) GetOccurrence(ctx context.Context, projectId, oc
 	occurrenceName := fmt.Sprintf("projects/%s/occurrences/%s", projectId, occurrenceId)
 	log := es.logger.Named("GetOccurrence").With(zap.String("occurrence", occurrenceName))
 
-	search := &esSearch{
+	search := &EsSearch{
 		Query: &filtering.Query{
 			Term: &filtering.Term{
 				"name": occurrenceName,
@@ -264,8 +264,8 @@ func (es *ElasticsearchStorage) BatchCreateOccurrences(ctx context.Context, proj
 	log := es.logger.Named("BatchCreateOccurrences")
 	log.Debug("creating occurrences")
 
-	indexMetadata := &esBulkQueryFragment{
-		Index: &esBulkQueryIndexFragment{
+	indexMetadata := &EsBulkQueryFragment{
+		Index: &EsBulkQueryIndexFragment{
 			Index: occurrencesIndex(projectId),
 		},
 	}
@@ -316,7 +316,7 @@ func (es *ElasticsearchStorage) BatchCreateOccurrences(ctx context.Context, proj
 		}
 	}
 
-	response := &esBulkResponse{}
+	response := &EsBulkResponse{}
 	err = decodeResponse(res.Body, response)
 	if err != nil {
 		return nil, []error{
@@ -363,7 +363,7 @@ func (es *ElasticsearchStorage) DeleteOccurrence(ctx context.Context, projectId,
 
 	log.Debug("deleting occurrence")
 
-	search := &esSearch{
+	search := &EsSearch{
 		Query: &filtering.Query{
 			Term: &filtering.Term{
 				"name": occurrenceName,
@@ -379,7 +379,7 @@ func (es *ElasticsearchStorage) GetNote(ctx context.Context, projectId, noteId s
 	noteName := fmt.Sprintf("projects/%s/notes/%s", projectId, noteId)
 	log := es.logger.Named("GetNote").With(zap.String("note", noteName))
 
-	search := &esSearch{
+	search := &EsSearch{
 		Query: &filtering.Query{
 			Term: &filtering.Term{
 				"name": noteName,
@@ -432,7 +432,7 @@ func (es *ElasticsearchStorage) CreateNote(ctx context.Context, projectId, noteI
 	log := es.logger.Named("CreateNote").With(zap.String("note", noteName))
 
 	// since note IDs are provided up front by the client, we need to search ES to see if this note already exists before creating it
-	search := &esSearch{
+	search := &EsSearch{
 		Query: &filtering.Query{
 			Term: &filtering.Term{
 				"name": noteName,
@@ -465,7 +465,7 @@ func (es *ElasticsearchStorage) BatchCreateNotes(ctx context.Context, projectId,
 	log := es.logger.Named("BatchCreateNotes").With(zap.String("projectId", projectId))
 	log.Debug("creating notes")
 
-	searchMetadata, _ := json.Marshal(&esMultiSearchQueryFragment{
+	searchMetadata, _ := json.Marshal(&EsMultiSearchQueryFragment{
 		Index: notesIndex(projectId),
 	})
 	searchMetadata = append(searchMetadata, "\n"...)
@@ -482,7 +482,7 @@ func (es *ElasticsearchStorage) BatchCreateNotes(ctx context.Context, projectId,
 
 		notes = append(notes, note)
 
-		searchBody := &esSearch{
+		searchBody := &EsSearch{
 			Query: &filtering.Query{
 				Term: &filtering.Term{
 					"name": note.Name,
@@ -515,7 +515,7 @@ func (es *ElasticsearchStorage) BatchCreateNotes(ctx context.Context, projectId,
 		}
 	}
 
-	searchResponse := &esMultiSearchResponse{}
+	searchResponse := &EsMultiSearchResponse{}
 	err = decodeResponse(res.Body, searchResponse)
 	if err != nil {
 		return nil, []error{
@@ -540,8 +540,8 @@ func (es *ElasticsearchStorage) BatchCreateNotes(ctx context.Context, projectId,
 		return nil, errs
 	}
 
-	indexMetadata, _ := json.Marshal(&esBulkQueryFragment{
-		Index: &esBulkQueryIndexFragment{
+	indexMetadata, _ := json.Marshal(&EsBulkQueryFragment{
+		Index: &EsBulkQueryIndexFragment{
 			Index: notesIndex(projectId),
 		},
 	})
@@ -576,7 +576,7 @@ func (es *ElasticsearchStorage) BatchCreateNotes(ctx context.Context, projectId,
 		return nil, append(errs, createError(log, "unexpected response from ES", nil, zap.Any("response", res.String()), zap.Int("status", res.StatusCode)))
 	}
 
-	bulkResponse := &esBulkResponse{}
+	bulkResponse := &EsBulkResponse{}
 	err = decodeResponse(res.Body, bulkResponse)
 	if err != nil {
 		return nil, append(errs, createError(log, "error decoding ES response", nil))
@@ -619,7 +619,7 @@ func (es *ElasticsearchStorage) DeleteNote(ctx context.Context, projectId, noteI
 
 	log.Debug("deleting note")
 
-	search := &esSearch{
+	search := &EsSearch{
 		Query: &filtering.Query{
 			Term: &filtering.Term{
 				"name": noteName,
@@ -645,7 +645,7 @@ func (es *ElasticsearchStorage) GetVulnerabilityOccurrencesSummary(ctx context.C
 	return &pb.VulnerabilityOccurrencesSummary{}, nil
 }
 
-func (es *ElasticsearchStorage) genericGet(ctx context.Context, log *zap.Logger, search *esSearch, index string, protoMessage interface{}) error {
+func (es *ElasticsearchStorage) genericGet(ctx context.Context, log *zap.Logger, search *EsSearch, index string, protoMessage interface{}) error {
 	encodedBody, requestJson := encodeRequest(search)
 	log = log.With(zap.String("request", requestJson))
 
@@ -661,7 +661,7 @@ func (es *ElasticsearchStorage) genericGet(ctx context.Context, log *zap.Logger,
 		return createError(log, "error searching elasticsearch for document", nil, zap.String("response", res.String()), zap.Int("status", res.StatusCode))
 	}
 
-	var searchResults esSearchResponse
+	var searchResults EsSearchResponse
 	if err := decodeResponse(res.Body, &searchResults); err != nil {
 		return createError(log, "error unmarshalling elasticsearch response", err)
 	}
@@ -694,7 +694,7 @@ func (es *ElasticsearchStorage) genericCreate(ctx context.Context, log *zap.Logg
 		return createError(log, "error indexing document in elasticsearch", nil, zap.String("response", res.String()), zap.Int("status", res.StatusCode))
 	}
 
-	esResponse := &esIndexDocResponse{}
+	esResponse := &EsIndexDocResponse{}
 	err = decodeResponse(res.Body, esResponse)
 	if err != nil {
 		return createError(log, "error decoding elasticsearch response", err)
@@ -705,7 +705,7 @@ func (es *ElasticsearchStorage) genericCreate(ctx context.Context, log *zap.Logg
 	return nil
 }
 
-func (es *ElasticsearchStorage) genericDelete(ctx context.Context, log *zap.Logger, search *esSearch, index string) error {
+func (es *ElasticsearchStorage) genericDelete(ctx context.Context, log *zap.Logger, search *EsSearch, index string) error {
 	encodedBody, requestJson := encodeRequest(search)
 	log = log.With(zap.String("request", requestJson))
 
@@ -722,7 +722,7 @@ func (es *ElasticsearchStorage) genericDelete(ctx context.Context, log *zap.Logg
 		return createError(log, "received unexpected response from elasticsearch", nil)
 	}
 
-	var deletedResults esDeleteResponse
+	var deletedResults EsDeleteResponse
 	if err = decodeResponse(res.Body, &deletedResults); err != nil {
 		return createError(log, "error unmarshalling elasticsearch response", err)
 	}
@@ -734,8 +734,8 @@ func (es *ElasticsearchStorage) genericDelete(ctx context.Context, log *zap.Logg
 	return nil
 }
 
-func (es *ElasticsearchStorage) genericList(ctx context.Context, log *zap.Logger, index, filter string, sort bool) (*esSearchResponseHits, error) {
-	body := &esSearch{}
+func (es *ElasticsearchStorage) genericList(ctx context.Context, log *zap.Logger, index, filter string, sort bool) (*EsSearchResponseHits, error) {
+	body := &EsSearch{}
 	if filter != "" {
 		log = log.With(zap.String("filter", filter))
 		filterQuery, err := es.filterer.ParseExpression(filter)
@@ -747,8 +747,8 @@ func (es *ElasticsearchStorage) genericList(ctx context.Context, log *zap.Logger
 	}
 
 	if sort {
-		body.Sort = map[string]esSortOrder{
-			sortField: esSortOrderDecending,
+		body.Sort = map[string]EsSortOrder{
+			sortField: EsSortOrderDescending,
 		}
 	}
 
@@ -769,7 +769,7 @@ func (es *ElasticsearchStorage) genericList(ctx context.Context, log *zap.Logger
 		return nil, createError(log, "unexpected response from elasticsearch", nil, zap.String("response", res.String()), zap.Int("status", res.StatusCode))
 	}
 
-	var searchResults esSearchResponse
+	var searchResults EsSearchResponse
 	if err := decodeResponse(res.Body, &searchResults); err != nil {
 		return nil, createError(log, "error decoding elasticsearch response", err)
 	}

--- a/go/v1beta1/storage/elasticsearch_test.go
+++ b/go/v1beta1/storage/elasticsearch_test.go
@@ -87,7 +87,7 @@ var _ = Describe("elasticsearch storage", func() {
 				},
 				{
 					StatusCode: http.StatusOK,
-					Body: structToJsonBody(&esIndexDocResponse{
+					Body: structToJsonBody(&EsIndexDocResponse{
 						Id: fake.LetterN(10),
 					}),
 				},
@@ -271,7 +271,7 @@ var _ = Describe("elasticsearch storage", func() {
 			requestBody, err := ioutil.ReadAll(transport.receivedHttpRequests[0].Body)
 			Expect(err).ToNot(HaveOccurred())
 
-			searchBody := &esSearch{}
+			searchBody := &EsSearch{}
 			err = json.Unmarshal(requestBody, searchBody)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(searchBody.Query).To(BeNil())
@@ -300,7 +300,7 @@ var _ = Describe("elasticsearch storage", func() {
 				requestBody, err := ioutil.ReadAll(transport.receivedHttpRequests[0].Body)
 				Expect(err).ToNot(HaveOccurred())
 
-				searchBody := &esSearch{}
+				searchBody := &EsSearch{}
 				err = json.Unmarshal(requestBody, searchBody)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(searchBody.Query).To(Equal(expectedQuery))
@@ -418,7 +418,7 @@ var _ = Describe("elasticsearch storage", func() {
 			requestBody, err := ioutil.ReadAll(transport.receivedHttpRequests[0].Body)
 			Expect(err).ToNot(HaveOccurred())
 
-			searchBody := &esSearch{}
+			searchBody := &EsSearch{}
 			err = json.Unmarshal(requestBody, searchBody)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -497,7 +497,7 @@ var _ = Describe("elasticsearch storage", func() {
 			transport.preparedHttpResponses = []*http.Response{
 				{
 					StatusCode: http.StatusOK,
-					Body: structToJsonBody(&esDeleteResponse{
+					Body: structToJsonBody(&EsDeleteResponse{
 						Deleted: 1,
 					}),
 				},
@@ -518,7 +518,7 @@ var _ = Describe("elasticsearch storage", func() {
 			requestBody, err := ioutil.ReadAll(transport.receivedHttpRequests[0].Body)
 			Expect(err).ToNot(HaveOccurred())
 
-			searchBody := &esSearch{}
+			searchBody := &EsSearch{}
 			err = json.Unmarshal(requestBody, searchBody)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -557,7 +557,7 @@ var _ = Describe("elasticsearch storage", func() {
 
 		When("elasticsearch successfully deletes the project document", func() {
 			BeforeEach(func() {
-				transport.preparedHttpResponses[0].Body = structToJsonBody(&esDeleteResponse{
+				transport.preparedHttpResponses[0].Body = structToJsonBody(&EsDeleteResponse{
 					Deleted: 1,
 				})
 			})
@@ -586,7 +586,7 @@ var _ = Describe("elasticsearch storage", func() {
 
 		When("project does not exist", func() {
 			BeforeEach(func() {
-				transport.preparedHttpResponses[0].Body = structToJsonBody(&esDeleteResponse{
+				transport.preparedHttpResponses[0].Body = structToJsonBody(&EsDeleteResponse{
 					Deleted: 0,
 				})
 			})
@@ -651,7 +651,7 @@ var _ = Describe("elasticsearch storage", func() {
 			requestBody, err := ioutil.ReadAll(transport.receivedHttpRequests[0].Body)
 			Expect(err).ToNot(HaveOccurred())
 
-			searchBody := &esSearch{}
+			searchBody := &EsSearch{}
 			err = json.Unmarshal(requestBody, searchBody)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -733,7 +733,7 @@ var _ = Describe("elasticsearch storage", func() {
 			transport.preparedHttpResponses = []*http.Response{
 				{
 					StatusCode: http.StatusCreated,
-					Body: structToJsonBody(&esIndexDocResponse{
+					Body: structToJsonBody(&EsIndexDocResponse{
 						Id: expectedOccurrenceESId,
 					}),
 				},
@@ -744,7 +744,7 @@ var _ = Describe("elasticsearch storage", func() {
 		JustBeforeEach(func() {
 			occurrence := deepCopyOccurrence(expectedOccurrence)
 
-			transport.preparedHttpResponses[0].Body = structToJsonBody(&esIndexDocResponse{
+			transport.preparedHttpResponses[0].Body = structToJsonBody(&EsIndexDocResponse{
 				Id: expectedOccurrenceESId,
 			})
 			actualOccurrence, actualErr = elasticsearchStorage.CreateOccurrence(context.Background(), expectedProjectId, "", occurrence)
@@ -798,8 +798,8 @@ var _ = Describe("elasticsearch storage", func() {
 			BeforeEach(func() {
 				transport.preparedHttpResponses[0] = &http.Response{
 					StatusCode: http.StatusInternalServerError,
-					Body: structToJsonBody(&esIndexDocResponse{
-						Error: &esIndexDocError{
+					Body: structToJsonBody(&EsIndexDocResponse{
+						Error: &EsIndexDocError{
 							Type:   fake.LetterN(10),
 							Reason: fake.LetterN(10),
 						},
@@ -862,14 +862,14 @@ var _ = Describe("elasticsearch storage", func() {
 			var expectedPayloads []interface{}
 
 			for i := 0; i < len(expectedOccurrences); i++ {
-				expectedPayloads = append(expectedPayloads, &esBulkQueryFragment{}, &pb.Occurrence{})
+				expectedPayloads = append(expectedPayloads, &EsBulkQueryFragment{}, &pb.Occurrence{})
 			}
 
 			parseEsBulkIndexRequest(transport.receivedHttpRequests[0].Body, expectedPayloads)
 
 			for i, payload := range expectedPayloads {
 				if i%2 == 0 { // index metadata
-					metadata := payload.(*esBulkQueryFragment)
+					metadata := payload.(*EsBulkQueryFragment)
 					Expect(metadata.Index.Index).To(Equal(expectedOccurrencesIndex))
 				} else { // occurrence
 					occurrence := payload.(*pb.Occurrence)
@@ -986,7 +986,7 @@ var _ = Describe("elasticsearch storage", func() {
 			transport.preparedHttpResponses = []*http.Response{
 				{
 					StatusCode: http.StatusOK,
-					Body: structToJsonBody(&esDeleteResponse{
+					Body: structToJsonBody(&EsDeleteResponse{
 						Deleted: 1,
 					}),
 				},
@@ -1008,7 +1008,7 @@ var _ = Describe("elasticsearch storage", func() {
 			requestBody, err := ioutil.ReadAll(transport.receivedHttpRequests[0].Body)
 			Expect(err).ToNot(HaveOccurred())
 
-			searchBody := &esSearch{}
+			searchBody := &EsSearch{}
 			err = json.Unmarshal(requestBody, searchBody)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -1047,7 +1047,7 @@ var _ = Describe("elasticsearch storage", func() {
 
 		When("elasticsearch successfully deletes the occurrence document", func() {
 			BeforeEach(func() {
-				transport.preparedHttpResponses[0].Body = structToJsonBody(&esDeleteResponse{
+				transport.preparedHttpResponses[0].Body = structToJsonBody(&EsDeleteResponse{
 					Deleted: 1,
 				})
 			})
@@ -1059,7 +1059,7 @@ var _ = Describe("elasticsearch storage", func() {
 
 		When("the occurrence does not exist", func() {
 			BeforeEach(func() {
-				transport.preparedHttpResponses[0].Body = structToJsonBody(&esDeleteResponse{
+				transport.preparedHttpResponses[0].Body = structToJsonBody(&EsDeleteResponse{
 					Deleted: 0,
 				})
 			})
@@ -1117,11 +1117,11 @@ var _ = Describe("elasticsearch storage", func() {
 			requestBody, err := ioutil.ReadAll(transport.receivedHttpRequests[0].Body)
 			Expect(err).ToNot(HaveOccurred())
 
-			searchBody := &esSearch{}
+			searchBody := &EsSearch{}
 			err = json.Unmarshal(requestBody, searchBody)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(searchBody.Query).To(BeNil())
-			Expect(searchBody.Sort[sortField]).To(Equal(esSortOrderDecending))
+			Expect(searchBody.Sort[sortField]).To(Equal(EsSortOrderDescending))
 		})
 
 		When("a valid filter is specified", func() {
@@ -1146,7 +1146,7 @@ var _ = Describe("elasticsearch storage", func() {
 				requestBody, err := ioutil.ReadAll(transport.receivedHttpRequests[0].Body)
 				Expect(err).ToNot(HaveOccurred())
 
-				searchBody := &esSearch{}
+				searchBody := &EsSearch{}
 				err = json.Unmarshal(requestBody, searchBody)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(searchBody.Query).To(Equal(expectedQuery))
@@ -1261,7 +1261,7 @@ var _ = Describe("elasticsearch storage", func() {
 				},
 				{
 					StatusCode: http.StatusCreated,
-					Body: structToJsonBody(&esIndexDocResponse{
+					Body: structToJsonBody(&EsIndexDocResponse{
 						Id: expectedNoteESId,
 					}),
 				},
@@ -1282,7 +1282,7 @@ var _ = Describe("elasticsearch storage", func() {
 			requestBody, err := ioutil.ReadAll(transport.receivedHttpRequests[0].Body)
 			Expect(err).ToNot(HaveOccurred())
 
-			searchBody := &esSearch{}
+			searchBody := &EsSearch{}
 			err = json.Unmarshal(requestBody, searchBody)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -1309,8 +1309,8 @@ var _ = Describe("elasticsearch storage", func() {
 				BeforeEach(func() {
 					transport.preparedHttpResponses[0] = &http.Response{
 						StatusCode: http.StatusInternalServerError,
-						Body: structToJsonBody(&esIndexDocResponse{
-							Error: &esIndexDocError{
+						Body: structToJsonBody(&EsIndexDocResponse{
+							Error: &EsIndexDocError{
 								Type:   fake.LetterN(10),
 								Reason: fake.LetterN(10),
 							},
@@ -1451,18 +1451,18 @@ var _ = Describe("elasticsearch storage", func() {
 			var expectedPayloads []interface{}
 
 			for i := 0; i < len(expectedNotesWithNoteIds); i++ {
-				expectedPayloads = append(expectedPayloads, &esMultiSearchQueryFragment{}, &esSearch{})
+				expectedPayloads = append(expectedPayloads, &EsMultiSearchQueryFragment{}, &EsSearch{})
 			}
 
 			parseEsMsearchIndexRequest(transport.receivedHttpRequests[0].Body, expectedPayloads)
 
 			for i, payload := range expectedPayloads {
 				if i%2 == 0 { // index metadata
-					metadata := payload.(*esMultiSearchQueryFragment)
+					metadata := payload.(*EsMultiSearchQueryFragment)
 					Expect(metadata.Index).To(Equal(expectedNotesIndex))
 				} else { // note
-					Expect(payload).To(BeAssignableToTypeOf(&esSearch{}))
-					Expect(map[string]string(*payload.(*esSearch).Query.Term)["name"]).To(MatchRegexp("projects/%s/notes/\\w+", expectedProjectId))
+					Expect(payload).To(BeAssignableToTypeOf(&EsSearch{}))
+					Expect(map[string]string(*payload.(*EsSearch).Query.Term)["name"]).To(MatchRegexp("projects/%s/notes/\\w+", expectedProjectId))
 				}
 			}
 		})
@@ -1487,14 +1487,14 @@ var _ = Describe("elasticsearch storage", func() {
 				var expectedPayloads []interface{}
 
 				for i := 0; i < len(expectedNotes); i++ {
-					expectedPayloads = append(expectedPayloads, &esBulkQueryFragment{}, &pb.Note{})
+					expectedPayloads = append(expectedPayloads, &EsBulkQueryFragment{}, &pb.Note{})
 				}
 
 				parseEsBulkIndexRequest(transport.receivedHttpRequests[1].Body, expectedPayloads)
 
 				for i, payload := range expectedPayloads {
 					if i%2 == 0 { // index metadata
-						metadata := payload.(*esBulkQueryFragment)
+						metadata := payload.(*EsBulkQueryFragment)
 						Expect(metadata.Index.Index).To(Equal(expectedNotesIndex))
 					} else { // note
 						note := payload.(*pb.Note)
@@ -1594,7 +1594,7 @@ var _ = Describe("elasticsearch storage", func() {
 			requestBody, err := ioutil.ReadAll(transport.receivedHttpRequests[0].Body)
 			Expect(err).ToNot(HaveOccurred())
 
-			searchBody := &esSearch{}
+			searchBody := &EsSearch{}
 			err = json.Unmarshal(requestBody, searchBody)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -1694,11 +1694,11 @@ var _ = Describe("elasticsearch storage", func() {
 			requestBody, err := ioutil.ReadAll(transport.receivedHttpRequests[0].Body)
 			Expect(err).ToNot(HaveOccurred())
 
-			searchBody := &esSearch{}
+			searchBody := &EsSearch{}
 			err = json.Unmarshal(requestBody, searchBody)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(searchBody.Query).To(BeNil())
-			Expect(searchBody.Sort[sortField]).To(Equal(esSortOrderDecending))
+			Expect(searchBody.Sort[sortField]).To(Equal(EsSortOrderDescending))
 		})
 
 		When("a valid filter is specified", func() {
@@ -1723,7 +1723,7 @@ var _ = Describe("elasticsearch storage", func() {
 				requestBody, err := ioutil.ReadAll(transport.receivedHttpRequests[0].Body)
 				Expect(err).ToNot(HaveOccurred())
 
-				searchBody := &esSearch{}
+				searchBody := &EsSearch{}
 				err = json.Unmarshal(requestBody, searchBody)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(searchBody.Query).To(Equal(expectedQuery))
@@ -1825,7 +1825,7 @@ var _ = Describe("elasticsearch storage", func() {
 			transport.preparedHttpResponses = []*http.Response{
 				{
 					StatusCode: http.StatusOK,
-					Body: structToJsonBody(&esDeleteResponse{
+					Body: structToJsonBody(&EsDeleteResponse{
 						Deleted: 1,
 					}),
 				},
@@ -1847,7 +1847,7 @@ var _ = Describe("elasticsearch storage", func() {
 			requestBody, err := ioutil.ReadAll(transport.receivedHttpRequests[0].Body)
 			Expect(err).ToNot(HaveOccurred())
 
-			searchBody := &esSearch{}
+			searchBody := &EsSearch{}
 			err = json.Unmarshal(requestBody, searchBody)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -1886,7 +1886,7 @@ var _ = Describe("elasticsearch storage", func() {
 
 		When("elasticsearch successfully deletes the note document", func() {
 			BeforeEach(func() {
-				transport.preparedHttpResponses[0].Body = structToJsonBody(&esDeleteResponse{
+				transport.preparedHttpResponses[0].Body = structToJsonBody(&EsDeleteResponse{
 					Deleted: 1,
 				})
 			})
@@ -1898,7 +1898,7 @@ var _ = Describe("elasticsearch storage", func() {
 
 		When("the note does not exist", func() {
 			BeforeEach(func() {
-				transport.preparedHttpResponses[0].Body = structToJsonBody(&esDeleteResponse{
+				transport.preparedHttpResponses[0].Body = structToJsonBody(&EsDeleteResponse{
 					Deleted: 0,
 				})
 			})
@@ -1948,21 +1948,21 @@ func createNoteEsSearchResponse(notes ...*pb.Note) io.ReadCloser {
 }
 
 func createGenericEsSearchResponse(messages ...proto.Message) io.ReadCloser {
-	var hits []*esSearchResponseHit
+	var hits []*EsSearchResponseHit
 
 	for _, m := range messages {
 		raw, err := protojson.Marshal(proto.MessageV2(m))
 		Expect(err).ToNot(HaveOccurred())
 
-		hits = append(hits, &esSearchResponseHit{
+		hits = append(hits, &EsSearchResponseHit{
 			Source: raw,
 		})
 	}
 
-	response := &esSearchResponse{
+	response := &EsSearchResponse{
 		Took: fake.Number(1, 10),
-		Hits: &esSearchResponseHits{
-			Total: &esSearchResponseTotal{
+		Hits: &EsSearchResponseHits{
+			Total: &EsSearchResponseTotal{
 				Value: len(hits),
 			},
 			Hits: hits,
@@ -1975,35 +1975,35 @@ func createGenericEsSearchResponse(messages ...proto.Message) io.ReadCloser {
 }
 
 func createEsSearchResponse(objectType string, hitNames ...string) io.ReadCloser {
-	var occurrenceHits []*esSearchResponseHit
+	var occurrenceHits []*EsSearchResponseHit
 
 	for _, hit := range hitNames {
 		switch objectType {
 		case "project":
 			rawGrafeasObject, err := json.Marshal(generateTestProject(hit))
 			Expect(err).ToNot(HaveOccurred())
-			occurrenceHits = append(occurrenceHits, &esSearchResponseHit{
+			occurrenceHits = append(occurrenceHits, &EsSearchResponseHit{
 				Source: rawGrafeasObject,
 			})
 		case "occurrence":
 			rawGrafeasObject, err := json.Marshal(generateTestOccurrence(hit))
 			Expect(err).ToNot(HaveOccurred())
-			occurrenceHits = append(occurrenceHits, &esSearchResponseHit{
+			occurrenceHits = append(occurrenceHits, &EsSearchResponseHit{
 				Source: rawGrafeasObject,
 			})
 		case "note":
 			rawGrafeasObject, err := json.Marshal(generateTestNote(hit))
 			Expect(err).ToNot(HaveOccurred())
-			occurrenceHits = append(occurrenceHits, &esSearchResponseHit{
+			occurrenceHits = append(occurrenceHits, &EsSearchResponseHit{
 				Source: rawGrafeasObject,
 			})
 		}
 	}
 
-	response := &esSearchResponse{
+	response := &EsSearchResponse{
 		Took: fake.Number(1, 10),
-		Hits: &esSearchResponseHits{
-			Total: &esSearchResponseTotal{
+		Hits: &EsSearchResponseHits{
+			Total: &EsSearchResponseTotal{
 				Value: len(hitNames),
 			},
 			Hits: occurrenceHits,
@@ -2017,16 +2017,16 @@ func createEsSearchResponse(objectType string, hitNames ...string) io.ReadCloser
 
 func createEsBulkOccurrenceIndexResponse(occurrences []*pb.Occurrence, errs []error) io.ReadCloser {
 	var (
-		responseItems     []*esBulkResponseItem
+		responseItems     []*EsBulkResponseItem
 		responseHasErrors = false
 	)
 	for i := range occurrences {
 		var (
-			responseErr  *esIndexDocError
+			responseErr  *EsIndexDocError
 			responseCode = http.StatusCreated
 		)
 		if errs[i] != nil {
-			responseErr = &esIndexDocError{
+			responseErr = &EsIndexDocError{
 				Type:   fake.LetterN(10),
 				Reason: fake.LetterN(10),
 			}
@@ -2034,8 +2034,8 @@ func createEsBulkOccurrenceIndexResponse(occurrences []*pb.Occurrence, errs []er
 			responseHasErrors = true
 		}
 
-		responseItems = append(responseItems, &esBulkResponseItem{
-			Index: &esIndexDocResponse{
+		responseItems = append(responseItems, &EsBulkResponseItem{
+			Index: &EsIndexDocResponse{
 				Id:     fake.LetterN(10),
 				Status: responseCode,
 				Error:  responseErr,
@@ -2043,7 +2043,7 @@ func createEsBulkOccurrenceIndexResponse(occurrences []*pb.Occurrence, errs []er
 		})
 	}
 
-	response := &esBulkResponse{
+	response := &EsBulkResponse{
 		Items:  responseItems,
 		Errors: responseHasErrors,
 	}
@@ -2055,17 +2055,17 @@ func createEsBulkOccurrenceIndexResponse(occurrences []*pb.Occurrence, errs []er
 }
 
 func createEsBulkNoteIndexResponse(notesThatCreatedSuccessfully map[string]*pb.Note) io.ReadCloser {
-	var responseItems []*esBulkResponseItem
+	var responseItems []*EsBulkResponseItem
 	for range notesThatCreatedSuccessfully {
-		responseItems = append(responseItems, &esBulkResponseItem{
-			Index: &esIndexDocResponse{
+		responseItems = append(responseItems, &EsBulkResponseItem{
+			Index: &EsIndexDocResponse{
 				Id:     fake.LetterN(10),
 				Status: http.StatusCreated,
 			},
 		})
 	}
 
-	response := &esBulkResponse{
+	response := &EsBulkResponse{
 		Items:  responseItems,
 		Errors: false,
 	}
@@ -2077,12 +2077,12 @@ func createEsBulkNoteIndexResponse(notesThatCreatedSuccessfully map[string]*pb.N
 }
 
 func createEsMultiSearchNoteResponse(notes map[string]*pb.Note) io.ReadCloser {
-	multiSearchResponse := &esMultiSearchResponse{}
+	multiSearchResponse := &EsMultiSearchResponse{}
 
 	for range notes {
-		multiSearchResponse.Responses = append(multiSearchResponse.Responses, &esMultiSearchResponseHitsSummary{
-			Hits: &esMultiSearchResponseHits{
-				Total: &esSearchResponseTotal{
+		multiSearchResponse.Responses = append(multiSearchResponse.Responses, &EsMultiSearchResponseHitsSummary{
+			Hits: &EsMultiSearchResponseHits{
+				Total: &EsSearchResponseTotal{
 					Value: 0,
 				},
 			},

--- a/go/v1beta1/storage/types.go
+++ b/go/v1beta1/storage/types.go
@@ -8,21 +8,21 @@ import (
 
 // Elasticsearch /_search response
 
-type esSearchResponse struct {
+type EsSearchResponse struct {
 	Took int                   `json:"took"`
-	Hits *esSearchResponseHits `json:"hits"`
+	Hits *EsSearchResponseHits `json:"hits"`
 }
 
-type esSearchResponseHits struct {
-	Total *esSearchResponseTotal `json:"total"`
-	Hits  []*esSearchResponseHit `json:"hits"`
+type EsSearchResponseHits struct {
+	Total *EsSearchResponseTotal `json:"total"`
+	Hits  []*EsSearchResponseHit `json:"hits"`
 }
 
-type esSearchResponseTotal struct {
+type EsSearchResponseTotal struct {
 	Value int `json:"value"`
 }
 
-type esSearchResponseHit struct {
+type EsSearchResponseHit struct {
 	ID         string          `json:"_id"`
 	Source     json.RawMessage `json:"_source"`
 	Highlights json.RawMessage `json:"highlight"`
@@ -31,79 +31,84 @@ type esSearchResponseHit struct {
 
 // Elasticsearch /_search query
 
-type esSearch struct {
-	Query *filtering.Query       `json:"query,omitempty"`
-	Sort  map[string]esSortOrder `json:"sort,omitempty"`
+type EsCollapse struct {
+	Field string `json:"field,omitempty"`
 }
 
-type esSortOrder string
+type EsSearch struct {
+	Query    *filtering.Query       `json:"query,omitempty"`
+	Sort     map[string]EsSortOrder `json:"sort,omitempty"`
+	Collapse *EsCollapse            `json:"collapse,omitempty"`
+}
+
+type EsSortOrder string
 
 const (
-	esSortOrderAscending esSortOrder = "asc"
-	esSortOrderDecending esSortOrder = "desc"
+	EsSortOrderAscending  EsSortOrder = "asc"
+	EsSortOrderDescending EsSortOrder = "desc"
 )
 
 // Elasticsearch /_doc response
 
-type esIndexDocResponse struct {
+type EsIndexDocResponse struct {
 	Id     string           `json:"_id"`
 	Status int              `json:"status"`
-	Error  *esIndexDocError `json:"error,omitempty"`
+	Error  *EsIndexDocError `json:"error,omitempty"`
 }
 
-type esIndexDocError struct {
+type EsIndexDocError struct {
 	Type   string `json:"type"`
 	Reason string `json:"reason"`
 }
 
 // Elasticsearch /_delete_by_query response
 
-type esDeleteResponse struct {
+type EsDeleteResponse struct {
 	Deleted int `json:"deleted"`
 }
 
 // Elasticsearch /_bulk query fragments
 
-type esBulkQueryFragment struct {
-	Index *esBulkQueryIndexFragment `json:"index"`
+type EsBulkQueryFragment struct {
+	Index *EsBulkQueryIndexFragment `json:"index"`
 }
 
-type esBulkQueryIndexFragment struct {
+type EsBulkQueryIndexFragment struct {
 	Index string `json:"_index"`
 }
 
 // Elasticsearch /_bulk response
 
-type esBulkResponse struct {
-	Items  []*esBulkResponseItem `json:"items"`
+type EsBulkResponse struct {
+	Items  []*EsBulkResponseItem `json:"items"`
 	Errors bool
 }
 
-type esBulkResponseItem struct {
-	Index *esIndexDocResponse `json:"index,omitempty"`
+type EsBulkResponseItem struct {
+	Index *EsIndexDocResponse `json:"index,omitempty"`
 }
 
 // Elasticsearch /_msearch query fragments
 
-type esMultiSearchQueryFragment struct {
+type EsMultiSearchQueryFragment struct {
 	Index string `json:"index"`
 }
 
 // Elasticsearch /_msearch response
 
-type esMultiSearchResponse struct {
-	Responses []*esMultiSearchResponseHitsSummary `json:"responses"`
+type EsMultiSearchResponse struct {
+	Responses []*EsMultiSearchResponseHitsSummary `json:"responses"`
 }
 
-type esMultiSearchResponseHitsSummary struct {
-	Hits *esMultiSearchResponseHits `json:"hits"`
+type EsMultiSearchResponseHitsSummary struct {
+	Hits *EsMultiSearchResponseHits `json:"hits"`
 }
 
-type esMultiSearchResponseHits struct {
-	Total *esSearchResponseTotal      `json:"total"`
-	Hits  []*esMultiSearchResponseHit `json:"hits"`
+type EsMultiSearchResponseHits struct {
+	Total *EsSearchResponseTotal      `json:"total"`
+	Hits  []*EsMultiSearchResponseHit `json:"hits"`
 }
 
-type esMultiSearchResponseHit struct {
+type EsMultiSearchResponseHit struct {
 	Source json.RawMessage `json:"_source"`
 }


### PR DESCRIPTION
We copied these types over to Rode in order to wire up Elasticsearch, but we could prevent some duplication by referencing these directly. If we'd rather not expose these just for the resources endpoint, we can vendor them in Rode. 