### PR TITLE
Revert exposing ES types and pin goreleaser 

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with: 
-          version: latest
+          version: v0.155.2
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/go/v1beta1/storage/elasticsearch_test.go
+++ b/go/v1beta1/storage/elasticsearch_test.go
@@ -87,7 +87,7 @@ var _ = Describe("elasticsearch storage", func() {
 				},
 				{
 					StatusCode: http.StatusOK,
-					Body: structToJsonBody(&EsIndexDocResponse{
+					Body: structToJsonBody(&esIndexDocResponse{
 						Id: fake.LetterN(10),
 					}),
 				},
@@ -271,7 +271,7 @@ var _ = Describe("elasticsearch storage", func() {
 			requestBody, err := ioutil.ReadAll(transport.receivedHttpRequests[0].Body)
 			Expect(err).ToNot(HaveOccurred())
 
-			searchBody := &EsSearch{}
+			searchBody := &esSearch{}
 			err = json.Unmarshal(requestBody, searchBody)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(searchBody.Query).To(BeNil())
@@ -300,7 +300,7 @@ var _ = Describe("elasticsearch storage", func() {
 				requestBody, err := ioutil.ReadAll(transport.receivedHttpRequests[0].Body)
 				Expect(err).ToNot(HaveOccurred())
 
-				searchBody := &EsSearch{}
+				searchBody := &esSearch{}
 				err = json.Unmarshal(requestBody, searchBody)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(searchBody.Query).To(Equal(expectedQuery))
@@ -418,7 +418,7 @@ var _ = Describe("elasticsearch storage", func() {
 			requestBody, err := ioutil.ReadAll(transport.receivedHttpRequests[0].Body)
 			Expect(err).ToNot(HaveOccurred())
 
-			searchBody := &EsSearch{}
+			searchBody := &esSearch{}
 			err = json.Unmarshal(requestBody, searchBody)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -497,7 +497,7 @@ var _ = Describe("elasticsearch storage", func() {
 			transport.preparedHttpResponses = []*http.Response{
 				{
 					StatusCode: http.StatusOK,
-					Body: structToJsonBody(&EsDeleteResponse{
+					Body: structToJsonBody(&esDeleteResponse{
 						Deleted: 1,
 					}),
 				},
@@ -518,7 +518,7 @@ var _ = Describe("elasticsearch storage", func() {
 			requestBody, err := ioutil.ReadAll(transport.receivedHttpRequests[0].Body)
 			Expect(err).ToNot(HaveOccurred())
 
-			searchBody := &EsSearch{}
+			searchBody := &esSearch{}
 			err = json.Unmarshal(requestBody, searchBody)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -557,7 +557,7 @@ var _ = Describe("elasticsearch storage", func() {
 
 		When("elasticsearch successfully deletes the project document", func() {
 			BeforeEach(func() {
-				transport.preparedHttpResponses[0].Body = structToJsonBody(&EsDeleteResponse{
+				transport.preparedHttpResponses[0].Body = structToJsonBody(&esDeleteResponse{
 					Deleted: 1,
 				})
 			})
@@ -586,7 +586,7 @@ var _ = Describe("elasticsearch storage", func() {
 
 		When("project does not exist", func() {
 			BeforeEach(func() {
-				transport.preparedHttpResponses[0].Body = structToJsonBody(&EsDeleteResponse{
+				transport.preparedHttpResponses[0].Body = structToJsonBody(&esDeleteResponse{
 					Deleted: 0,
 				})
 			})
@@ -651,7 +651,7 @@ var _ = Describe("elasticsearch storage", func() {
 			requestBody, err := ioutil.ReadAll(transport.receivedHttpRequests[0].Body)
 			Expect(err).ToNot(HaveOccurred())
 
-			searchBody := &EsSearch{}
+			searchBody := &esSearch{}
 			err = json.Unmarshal(requestBody, searchBody)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -733,7 +733,7 @@ var _ = Describe("elasticsearch storage", func() {
 			transport.preparedHttpResponses = []*http.Response{
 				{
 					StatusCode: http.StatusCreated,
-					Body: structToJsonBody(&EsIndexDocResponse{
+					Body: structToJsonBody(&esIndexDocResponse{
 						Id: expectedOccurrenceESId,
 					}),
 				},
@@ -744,7 +744,7 @@ var _ = Describe("elasticsearch storage", func() {
 		JustBeforeEach(func() {
 			occurrence := deepCopyOccurrence(expectedOccurrence)
 
-			transport.preparedHttpResponses[0].Body = structToJsonBody(&EsIndexDocResponse{
+			transport.preparedHttpResponses[0].Body = structToJsonBody(&esIndexDocResponse{
 				Id: expectedOccurrenceESId,
 			})
 			actualOccurrence, actualErr = elasticsearchStorage.CreateOccurrence(context.Background(), expectedProjectId, "", occurrence)
@@ -798,8 +798,8 @@ var _ = Describe("elasticsearch storage", func() {
 			BeforeEach(func() {
 				transport.preparedHttpResponses[0] = &http.Response{
 					StatusCode: http.StatusInternalServerError,
-					Body: structToJsonBody(&EsIndexDocResponse{
-						Error: &EsIndexDocError{
+					Body: structToJsonBody(&esIndexDocResponse{
+						Error: &esIndexDocError{
 							Type:   fake.LetterN(10),
 							Reason: fake.LetterN(10),
 						},
@@ -862,14 +862,14 @@ var _ = Describe("elasticsearch storage", func() {
 			var expectedPayloads []interface{}
 
 			for i := 0; i < len(expectedOccurrences); i++ {
-				expectedPayloads = append(expectedPayloads, &EsBulkQueryFragment{}, &pb.Occurrence{})
+				expectedPayloads = append(expectedPayloads, &esBulkQueryFragment{}, &pb.Occurrence{})
 			}
 
 			parseEsBulkIndexRequest(transport.receivedHttpRequests[0].Body, expectedPayloads)
 
 			for i, payload := range expectedPayloads {
 				if i%2 == 0 { // index metadata
-					metadata := payload.(*EsBulkQueryFragment)
+					metadata := payload.(*esBulkQueryFragment)
 					Expect(metadata.Index.Index).To(Equal(expectedOccurrencesIndex))
 				} else { // occurrence
 					occurrence := payload.(*pb.Occurrence)
@@ -986,7 +986,7 @@ var _ = Describe("elasticsearch storage", func() {
 			transport.preparedHttpResponses = []*http.Response{
 				{
 					StatusCode: http.StatusOK,
-					Body: structToJsonBody(&EsDeleteResponse{
+					Body: structToJsonBody(&esDeleteResponse{
 						Deleted: 1,
 					}),
 				},
@@ -1008,7 +1008,7 @@ var _ = Describe("elasticsearch storage", func() {
 			requestBody, err := ioutil.ReadAll(transport.receivedHttpRequests[0].Body)
 			Expect(err).ToNot(HaveOccurred())
 
-			searchBody := &EsSearch{}
+			searchBody := &esSearch{}
 			err = json.Unmarshal(requestBody, searchBody)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -1047,7 +1047,7 @@ var _ = Describe("elasticsearch storage", func() {
 
 		When("elasticsearch successfully deletes the occurrence document", func() {
 			BeforeEach(func() {
-				transport.preparedHttpResponses[0].Body = structToJsonBody(&EsDeleteResponse{
+				transport.preparedHttpResponses[0].Body = structToJsonBody(&esDeleteResponse{
 					Deleted: 1,
 				})
 			})
@@ -1059,7 +1059,7 @@ var _ = Describe("elasticsearch storage", func() {
 
 		When("the occurrence does not exist", func() {
 			BeforeEach(func() {
-				transport.preparedHttpResponses[0].Body = structToJsonBody(&EsDeleteResponse{
+				transport.preparedHttpResponses[0].Body = structToJsonBody(&esDeleteResponse{
 					Deleted: 0,
 				})
 			})
@@ -1117,11 +1117,11 @@ var _ = Describe("elasticsearch storage", func() {
 			requestBody, err := ioutil.ReadAll(transport.receivedHttpRequests[0].Body)
 			Expect(err).ToNot(HaveOccurred())
 
-			searchBody := &EsSearch{}
+			searchBody := &esSearch{}
 			err = json.Unmarshal(requestBody, searchBody)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(searchBody.Query).To(BeNil())
-			Expect(searchBody.Sort[sortField]).To(Equal(EsSortOrderDescending))
+			Expect(searchBody.Sort[sortField]).To(Equal(esSortOrderDecending))
 		})
 
 		When("a valid filter is specified", func() {
@@ -1146,7 +1146,7 @@ var _ = Describe("elasticsearch storage", func() {
 				requestBody, err := ioutil.ReadAll(transport.receivedHttpRequests[0].Body)
 				Expect(err).ToNot(HaveOccurred())
 
-				searchBody := &EsSearch{}
+				searchBody := &esSearch{}
 				err = json.Unmarshal(requestBody, searchBody)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(searchBody.Query).To(Equal(expectedQuery))
@@ -1261,7 +1261,7 @@ var _ = Describe("elasticsearch storage", func() {
 				},
 				{
 					StatusCode: http.StatusCreated,
-					Body: structToJsonBody(&EsIndexDocResponse{
+					Body: structToJsonBody(&esIndexDocResponse{
 						Id: expectedNoteESId,
 					}),
 				},
@@ -1282,7 +1282,7 @@ var _ = Describe("elasticsearch storage", func() {
 			requestBody, err := ioutil.ReadAll(transport.receivedHttpRequests[0].Body)
 			Expect(err).ToNot(HaveOccurred())
 
-			searchBody := &EsSearch{}
+			searchBody := &esSearch{}
 			err = json.Unmarshal(requestBody, searchBody)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -1309,8 +1309,8 @@ var _ = Describe("elasticsearch storage", func() {
 				BeforeEach(func() {
 					transport.preparedHttpResponses[0] = &http.Response{
 						StatusCode: http.StatusInternalServerError,
-						Body: structToJsonBody(&EsIndexDocResponse{
-							Error: &EsIndexDocError{
+						Body: structToJsonBody(&esIndexDocResponse{
+							Error: &esIndexDocError{
 								Type:   fake.LetterN(10),
 								Reason: fake.LetterN(10),
 							},
@@ -1451,18 +1451,18 @@ var _ = Describe("elasticsearch storage", func() {
 			var expectedPayloads []interface{}
 
 			for i := 0; i < len(expectedNotesWithNoteIds); i++ {
-				expectedPayloads = append(expectedPayloads, &EsMultiSearchQueryFragment{}, &EsSearch{})
+				expectedPayloads = append(expectedPayloads, &esMultiSearchQueryFragment{}, &esSearch{})
 			}
 
 			parseEsMsearchIndexRequest(transport.receivedHttpRequests[0].Body, expectedPayloads)
 
 			for i, payload := range expectedPayloads {
 				if i%2 == 0 { // index metadata
-					metadata := payload.(*EsMultiSearchQueryFragment)
+					metadata := payload.(*esMultiSearchQueryFragment)
 					Expect(metadata.Index).To(Equal(expectedNotesIndex))
 				} else { // note
-					Expect(payload).To(BeAssignableToTypeOf(&EsSearch{}))
-					Expect(map[string]string(*payload.(*EsSearch).Query.Term)["name"]).To(MatchRegexp("projects/%s/notes/\\w+", expectedProjectId))
+					Expect(payload).To(BeAssignableToTypeOf(&esSearch{}))
+					Expect(map[string]string(*payload.(*esSearch).Query.Term)["name"]).To(MatchRegexp("projects/%s/notes/\\w+", expectedProjectId))
 				}
 			}
 		})
@@ -1487,14 +1487,14 @@ var _ = Describe("elasticsearch storage", func() {
 				var expectedPayloads []interface{}
 
 				for i := 0; i < len(expectedNotes); i++ {
-					expectedPayloads = append(expectedPayloads, &EsBulkQueryFragment{}, &pb.Note{})
+					expectedPayloads = append(expectedPayloads, &esBulkQueryFragment{}, &pb.Note{})
 				}
 
 				parseEsBulkIndexRequest(transport.receivedHttpRequests[1].Body, expectedPayloads)
 
 				for i, payload := range expectedPayloads {
 					if i%2 == 0 { // index metadata
-						metadata := payload.(*EsBulkQueryFragment)
+						metadata := payload.(*esBulkQueryFragment)
 						Expect(metadata.Index.Index).To(Equal(expectedNotesIndex))
 					} else { // note
 						note := payload.(*pb.Note)
@@ -1594,7 +1594,7 @@ var _ = Describe("elasticsearch storage", func() {
 			requestBody, err := ioutil.ReadAll(transport.receivedHttpRequests[0].Body)
 			Expect(err).ToNot(HaveOccurred())
 
-			searchBody := &EsSearch{}
+			searchBody := &esSearch{}
 			err = json.Unmarshal(requestBody, searchBody)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -1694,11 +1694,11 @@ var _ = Describe("elasticsearch storage", func() {
 			requestBody, err := ioutil.ReadAll(transport.receivedHttpRequests[0].Body)
 			Expect(err).ToNot(HaveOccurred())
 
-			searchBody := &EsSearch{}
+			searchBody := &esSearch{}
 			err = json.Unmarshal(requestBody, searchBody)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(searchBody.Query).To(BeNil())
-			Expect(searchBody.Sort[sortField]).To(Equal(EsSortOrderDescending))
+			Expect(searchBody.Sort[sortField]).To(Equal(esSortOrderDecending))
 		})
 
 		When("a valid filter is specified", func() {
@@ -1723,7 +1723,7 @@ var _ = Describe("elasticsearch storage", func() {
 				requestBody, err := ioutil.ReadAll(transport.receivedHttpRequests[0].Body)
 				Expect(err).ToNot(HaveOccurred())
 
-				searchBody := &EsSearch{}
+				searchBody := &esSearch{}
 				err = json.Unmarshal(requestBody, searchBody)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(searchBody.Query).To(Equal(expectedQuery))
@@ -1825,7 +1825,7 @@ var _ = Describe("elasticsearch storage", func() {
 			transport.preparedHttpResponses = []*http.Response{
 				{
 					StatusCode: http.StatusOK,
-					Body: structToJsonBody(&EsDeleteResponse{
+					Body: structToJsonBody(&esDeleteResponse{
 						Deleted: 1,
 					}),
 				},
@@ -1847,7 +1847,7 @@ var _ = Describe("elasticsearch storage", func() {
 			requestBody, err := ioutil.ReadAll(transport.receivedHttpRequests[0].Body)
 			Expect(err).ToNot(HaveOccurred())
 
-			searchBody := &EsSearch{}
+			searchBody := &esSearch{}
 			err = json.Unmarshal(requestBody, searchBody)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -1886,7 +1886,7 @@ var _ = Describe("elasticsearch storage", func() {
 
 		When("elasticsearch successfully deletes the note document", func() {
 			BeforeEach(func() {
-				transport.preparedHttpResponses[0].Body = structToJsonBody(&EsDeleteResponse{
+				transport.preparedHttpResponses[0].Body = structToJsonBody(&esDeleteResponse{
 					Deleted: 1,
 				})
 			})
@@ -1898,7 +1898,7 @@ var _ = Describe("elasticsearch storage", func() {
 
 		When("the note does not exist", func() {
 			BeforeEach(func() {
-				transport.preparedHttpResponses[0].Body = structToJsonBody(&EsDeleteResponse{
+				transport.preparedHttpResponses[0].Body = structToJsonBody(&esDeleteResponse{
 					Deleted: 0,
 				})
 			})
@@ -1948,21 +1948,21 @@ func createNoteEsSearchResponse(notes ...*pb.Note) io.ReadCloser {
 }
 
 func createGenericEsSearchResponse(messages ...proto.Message) io.ReadCloser {
-	var hits []*EsSearchResponseHit
+	var hits []*esSearchResponseHit
 
 	for _, m := range messages {
 		raw, err := protojson.Marshal(proto.MessageV2(m))
 		Expect(err).ToNot(HaveOccurred())
 
-		hits = append(hits, &EsSearchResponseHit{
+		hits = append(hits, &esSearchResponseHit{
 			Source: raw,
 		})
 	}
 
-	response := &EsSearchResponse{
+	response := &esSearchResponse{
 		Took: fake.Number(1, 10),
-		Hits: &EsSearchResponseHits{
-			Total: &EsSearchResponseTotal{
+		Hits: &esSearchResponseHits{
+			Total: &esSearchResponseTotal{
 				Value: len(hits),
 			},
 			Hits: hits,
@@ -1975,35 +1975,35 @@ func createGenericEsSearchResponse(messages ...proto.Message) io.ReadCloser {
 }
 
 func createEsSearchResponse(objectType string, hitNames ...string) io.ReadCloser {
-	var occurrenceHits []*EsSearchResponseHit
+	var occurrenceHits []*esSearchResponseHit
 
 	for _, hit := range hitNames {
 		switch objectType {
 		case "project":
 			rawGrafeasObject, err := json.Marshal(generateTestProject(hit))
 			Expect(err).ToNot(HaveOccurred())
-			occurrenceHits = append(occurrenceHits, &EsSearchResponseHit{
+			occurrenceHits = append(occurrenceHits, &esSearchResponseHit{
 				Source: rawGrafeasObject,
 			})
 		case "occurrence":
 			rawGrafeasObject, err := json.Marshal(generateTestOccurrence(hit))
 			Expect(err).ToNot(HaveOccurred())
-			occurrenceHits = append(occurrenceHits, &EsSearchResponseHit{
+			occurrenceHits = append(occurrenceHits, &esSearchResponseHit{
 				Source: rawGrafeasObject,
 			})
 		case "note":
 			rawGrafeasObject, err := json.Marshal(generateTestNote(hit))
 			Expect(err).ToNot(HaveOccurred())
-			occurrenceHits = append(occurrenceHits, &EsSearchResponseHit{
+			occurrenceHits = append(occurrenceHits, &esSearchResponseHit{
 				Source: rawGrafeasObject,
 			})
 		}
 	}
 
-	response := &EsSearchResponse{
+	response := &esSearchResponse{
 		Took: fake.Number(1, 10),
-		Hits: &EsSearchResponseHits{
-			Total: &EsSearchResponseTotal{
+		Hits: &esSearchResponseHits{
+			Total: &esSearchResponseTotal{
 				Value: len(hitNames),
 			},
 			Hits: occurrenceHits,
@@ -2017,16 +2017,16 @@ func createEsSearchResponse(objectType string, hitNames ...string) io.ReadCloser
 
 func createEsBulkOccurrenceIndexResponse(occurrences []*pb.Occurrence, errs []error) io.ReadCloser {
 	var (
-		responseItems     []*EsBulkResponseItem
+		responseItems     []*esBulkResponseItem
 		responseHasErrors = false
 	)
 	for i := range occurrences {
 		var (
-			responseErr  *EsIndexDocError
+			responseErr  *esIndexDocError
 			responseCode = http.StatusCreated
 		)
 		if errs[i] != nil {
-			responseErr = &EsIndexDocError{
+			responseErr = &esIndexDocError{
 				Type:   fake.LetterN(10),
 				Reason: fake.LetterN(10),
 			}
@@ -2034,8 +2034,8 @@ func createEsBulkOccurrenceIndexResponse(occurrences []*pb.Occurrence, errs []er
 			responseHasErrors = true
 		}
 
-		responseItems = append(responseItems, &EsBulkResponseItem{
-			Index: &EsIndexDocResponse{
+		responseItems = append(responseItems, &esBulkResponseItem{
+			Index: &esIndexDocResponse{
 				Id:     fake.LetterN(10),
 				Status: responseCode,
 				Error:  responseErr,
@@ -2043,7 +2043,7 @@ func createEsBulkOccurrenceIndexResponse(occurrences []*pb.Occurrence, errs []er
 		})
 	}
 
-	response := &EsBulkResponse{
+	response := &esBulkResponse{
 		Items:  responseItems,
 		Errors: responseHasErrors,
 	}
@@ -2055,17 +2055,17 @@ func createEsBulkOccurrenceIndexResponse(occurrences []*pb.Occurrence, errs []er
 }
 
 func createEsBulkNoteIndexResponse(notesThatCreatedSuccessfully map[string]*pb.Note) io.ReadCloser {
-	var responseItems []*EsBulkResponseItem
+	var responseItems []*esBulkResponseItem
 	for range notesThatCreatedSuccessfully {
-		responseItems = append(responseItems, &EsBulkResponseItem{
-			Index: &EsIndexDocResponse{
+		responseItems = append(responseItems, &esBulkResponseItem{
+			Index: &esIndexDocResponse{
 				Id:     fake.LetterN(10),
 				Status: http.StatusCreated,
 			},
 		})
 	}
 
-	response := &EsBulkResponse{
+	response := &esBulkResponse{
 		Items:  responseItems,
 		Errors: false,
 	}
@@ -2077,12 +2077,12 @@ func createEsBulkNoteIndexResponse(notesThatCreatedSuccessfully map[string]*pb.N
 }
 
 func createEsMultiSearchNoteResponse(notes map[string]*pb.Note) io.ReadCloser {
-	multiSearchResponse := &EsMultiSearchResponse{}
+	multiSearchResponse := &esMultiSearchResponse{}
 
 	for range notes {
-		multiSearchResponse.Responses = append(multiSearchResponse.Responses, &EsMultiSearchResponseHitsSummary{
-			Hits: &EsMultiSearchResponseHits{
-				Total: &EsSearchResponseTotal{
+		multiSearchResponse.Responses = append(multiSearchResponse.Responses, &esMultiSearchResponseHitsSummary{
+			Hits: &esMultiSearchResponseHits{
+				Total: &esSearchResponseTotal{
 					Value: 0,
 				},
 			},

--- a/go/v1beta1/storage/types.go
+++ b/go/v1beta1/storage/types.go
@@ -8,21 +8,21 @@ import (
 
 // Elasticsearch /_search response
 
-type EsSearchResponse struct {
+type esSearchResponse struct {
 	Took int                   `json:"took"`
-	Hits *EsSearchResponseHits `json:"hits"`
+	Hits *esSearchResponseHits `json:"hits"`
 }
 
-type EsSearchResponseHits struct {
-	Total *EsSearchResponseTotal `json:"total"`
-	Hits  []*EsSearchResponseHit `json:"hits"`
+type esSearchResponseHits struct {
+	Total *esSearchResponseTotal `json:"total"`
+	Hits  []*esSearchResponseHit `json:"hits"`
 }
 
-type EsSearchResponseTotal struct {
+type esSearchResponseTotal struct {
 	Value int `json:"value"`
 }
 
-type EsSearchResponseHit struct {
+type esSearchResponseHit struct {
 	ID         string          `json:"_id"`
 	Source     json.RawMessage `json:"_source"`
 	Highlights json.RawMessage `json:"highlight"`
@@ -31,84 +31,79 @@ type EsSearchResponseHit struct {
 
 // Elasticsearch /_search query
 
-type EsCollapse struct {
-	Field string `json:"field,omitempty"`
+type esSearch struct {
+	Query *filtering.Query       `json:"query,omitempty"`
+	Sort  map[string]esSortOrder `json:"sort,omitempty"`
 }
 
-type EsSearch struct {
-	Query    *filtering.Query       `json:"query,omitempty"`
-	Sort     map[string]EsSortOrder `json:"sort,omitempty"`
-	Collapse *EsCollapse            `json:"collapse,omitempty"`
-}
-
-type EsSortOrder string
+type esSortOrder string
 
 const (
-	EsSortOrderAscending  EsSortOrder = "asc"
-	EsSortOrderDescending EsSortOrder = "desc"
+	esSortOrderAscending esSortOrder = "asc"
+	esSortOrderDecending esSortOrder = "desc"
 )
 
 // Elasticsearch /_doc response
 
-type EsIndexDocResponse struct {
+type esIndexDocResponse struct {
 	Id     string           `json:"_id"`
 	Status int              `json:"status"`
-	Error  *EsIndexDocError `json:"error,omitempty"`
+	Error  *esIndexDocError `json:"error,omitempty"`
 }
 
-type EsIndexDocError struct {
+type esIndexDocError struct {
 	Type   string `json:"type"`
 	Reason string `json:"reason"`
 }
 
 // Elasticsearch /_delete_by_query response
 
-type EsDeleteResponse struct {
+type esDeleteResponse struct {
 	Deleted int `json:"deleted"`
 }
 
 // Elasticsearch /_bulk query fragments
 
-type EsBulkQueryFragment struct {
-	Index *EsBulkQueryIndexFragment `json:"index"`
+type esBulkQueryFragment struct {
+	Index *esBulkQueryIndexFragment `json:"index"`
 }
 
-type EsBulkQueryIndexFragment struct {
+type esBulkQueryIndexFragment struct {
 	Index string `json:"_index"`
 }
 
 // Elasticsearch /_bulk response
 
-type EsBulkResponse struct {
-	Items  []*EsBulkResponseItem `json:"items"`
+type esBulkResponse struct {
+	Items  []*esBulkResponseItem `json:"items"`
 	Errors bool
 }
 
-type EsBulkResponseItem struct {
-	Index *EsIndexDocResponse `json:"index,omitempty"`
+type esBulkResponseItem struct {
+	Index *esIndexDocResponse `json:"index,omitempty"`
 }
 
 // Elasticsearch /_msearch query fragments
 
-type EsMultiSearchQueryFragment struct {
+type esMultiSearchQueryFragment struct {
 	Index string `json:"index"`
 }
 
 // Elasticsearch /_msearch response
 
-type EsMultiSearchResponse struct {
-	Responses []*EsMultiSearchResponseHitsSummary `json:"responses"`
+type esMultiSearchResponse struct {
+	Responses []*esMultiSearchResponseHitsSummary `json:"responses"`
 }
 
-type EsMultiSearchResponseHitsSummary struct {
-	Hits *EsMultiSearchResponseHits `json:"hits"`
+type esMultiSearchResponseHitsSummary struct {
+	Hits *esMultiSearchResponseHits `json:"hits"`
 }
 
-type EsMultiSearchResponseHits struct {
-	Total *EsSearchResponseTotal      `json:"total"`
-	Hits  []*EsMultiSearchResponseHit `json:"hits"`
+type esMultiSearchResponseHits struct {
+	Total *esSearchResponseTotal      `json:"total"`
+	Hits  []*esMultiSearchResponseHit `json:"hits"`
 }
 
-type EsMultiSearchResponseHit struct {
+type esMultiSearchResponseHit struct {
 	Source json.RawMessage `json:"_source"`
 }


### PR DESCRIPTION
This PR reverts #38 -- depending on the `storage` package of `grafeas-elasticsearch` in Rode causes us to pull in a copy of Grafeas; which registers its protobuf declarations into the [global registry](https://developers.google.com/protocol-buffers/docs/reference/go/faq#namespace-conflict) and prints a bunch of warnings at app start:

```
[rode] 2021/02/18 17:22:07 WARNING: proto: message grafeas.v1beta1.Occurrence is already registered
[rode] A future release will panic on registration conflicts. See:
[rode] https://developers.google.com/protocol-buffers/docs/reference/go/faq#namespace-conflict
```

The only way I can think to get around that would be to refactor `grafeas-elasticsearch` and extract some of the components into their own package that doesn't reference Grafeas. That would be a bigger effort than just duplicating the types for now. 

Also in the process of releasing those changes, the pipeline publish action [failed](https://github.com/rode/grafeas-elasticsearch/runs/1929108312#step:5:58) trying to build for Apple ARM, because goreleaser recently added support. This downgrades the version of goreleaser until they release a fix for Go 1.15. 