### PR TITLE
Rode 47 updateOccurrence

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ docker run \
   -p 8080:8080 \
   -v ./config.yaml:/etc/grafeas/config.yaml \
   ghcr.io/rode/grafeas-elasticsearch --config /etc/grafeas/config.yaml
-````
+```
 
 A configuration file must be provided, with the path specified with a `--config` flag.
 
@@ -35,18 +35,18 @@ grafeas:
     keyfile:
     certfile:
     cors_allowed_origins:
-  
+
   # Must be `elasticsearch`
   storage_type: elasticsearch
-  
+
   elasticsearch:
     # URL to external Elasticsearch
     url: "http://elasticsearch:9200"
-    
+
     # Basic auth to external Elasticsearch
     username: "grafeas"
     password: "grafeas"
-    
+
     # How Grafeas should interact with Elasticsearch index refreshes.
     # Recommend using `true`, unless unique circumstances require otherwise.
     # Options are `true`, `wait_for`, `false`.
@@ -68,7 +68,7 @@ currently implemented features, along with the features that have not been imple
   - [x] `BatchCreateOccurrences`
   - [x] `GetOccurrence`
   - [x] `ListOccurrences`
-  - [ ] `UpdateOccurrence`
+  - [x] `UpdateOccurrence`
   - [x] `DeleteOccurrence`
 - [ ] Note Methods
   - [x] `CreateNote`
@@ -101,7 +101,7 @@ currently implemented features, along with the features that have not been imple
   - [x] Index refresh behavior
   - [ ] Basic Auth
   - [ ] SSL
-  
+
 ## Local Development
 
 - [Go](https://golang.org/)
@@ -121,7 +121,7 @@ Unit tests live alongside production code in `go/` directory.
 
 `make test` will run unit tests, along with vet and fmt.
 
-`go test unit` IDE run configuration is also available. 
+`go test unit` IDE run configuration is also available.
 
 `make mocks` will regenerate test mocks in `go/mocks` directory.
 
@@ -132,10 +132,10 @@ These require Elasticsearch and a build of this project to be running.
 This is handled through `docker-compose`.
 
 1. `docker-compose up -d --build elasticsearch server`
-    - Remove `-d` if you want to watch logs.
-    - Remove `--build` if you have already built the local images against the latest code.
-   Skipping build will significantly improve startup time.
+   - Remove `-d` if you want to watch logs.
+   - Remove `--build` if you have already built the local images against the latest code.
+     Skipping build will significantly improve startup time.
 1. `make integration` or `go test integration` IDE run configuration
    - Can be continuously run between docker-compose resets.
-   Tests generate UUIDs for resources, to avoid collisions between runs.
+     Tests generate UUIDs for resources, to avoid collisions between runs.
 1. `docker-compose down`

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/google/uuid v1.1.2
 	github.com/grafeas/grafeas v0.1.6
 	github.com/hashicorp/go-multierror v1.0.0
+	github.com/mennanov/fieldmask-utils v0.3.3
 	github.com/onsi/ginkgo v1.14.2
 	github.com/onsi/gomega v1.10.3
 	github.com/pelletier/go-toml v1.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -187,6 +187,8 @@ github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaO
 github.com/mattn/go-isatty v0.0.3 h1:ns/ykhmWi7G9O+8a448SecJU3nSMBXJfqQkl0upE1jI=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
+github.com/mennanov/fieldmask-utils v0.3.3 h1:/cAjLk3ja74dQJ0BBxEsK4xyzvECcOYLLB1lo6HuLog=
+github.com/mennanov/fieldmask-utils v0.3.3/go.mod h1:OcOWam4DG685inAjtNuFONKpkitiCCK1W5yKljvWwCY=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
@@ -423,6 +425,7 @@ google.golang.org/genproto v0.0.0-20200305110556-506484158171/go.mod h1:55QSHmfG
 google.golang.org/genproto v0.0.0-20200416231807-8751e049a2a0/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
 google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 h1:+kGHl1aib/qcwaRi1CbqBZ1rk19r85MNUf8HaBghugY=
 google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013/go.mod h1:NbSheEEYHJ7i3ixzK3sjbqSGDJWnxyFXZblF3eUsNvo=
+google.golang.org/genproto v0.0.0-20200527145253-8367513e4ece/go.mod h1:jDfRM7FcilCzHH/e9qn6dsT145K34l5v+OpcnNgKAAA=
 google.golang.org/genproto v0.0.0-20200806141610-86f49bd18e98 h1:LCO0fg4kb6WwkXQXRQQgUYsFeFb5taTX5WAx5O/Vt28=
 google.golang.org/genproto v0.0.0-20200806141610-86f49bd18e98/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=

--- a/go/v1beta1/storage/elasticsearch.go
+++ b/go/v1beta1/storage/elasticsearch.go
@@ -389,8 +389,10 @@ func (es *ElasticsearchStorage) UpdateOccurrence(ctx context.Context, projectId,
 		return nil, err
 	}
 
-	// TO DISCUSS. Remove the updateTime as the responsibility may be up to the updater
-	// o.UpdateTime = ptypes.TimestampNow()
+	if o.UpdateTime == nil {
+		mask.Paths = append(mask.Paths, "UpdateTime")
+		o.UpdateTime = ptypes.TimestampNow()
+	}
 
 	m, err := fieldmask_utils.MaskFromPaths(mask.Paths, generator.CamelCase)
 	if err != nil {

--- a/go/v1beta1/storage/elasticsearch.go
+++ b/go/v1beta1/storage/elasticsearch.go
@@ -393,7 +393,7 @@ func (es *ElasticsearchStorage) UpdateOccurrence(ctx context.Context, projectId,
 
 	m, err := fieldmask_utils.MaskFromPaths(mask.Paths, generator.CamelCase)
 	if err != nil {
-		log.Info("errors while mapping occurrences", zap.Any("errors", err))
+		log.Info("errors while mapping masks", zap.Any("errors", err))
 		return occurrence, err
 	}
 	fieldmask_utils.StructToStruct(m, o, occurrence)

--- a/go/v1beta1/storage/elasticsearch.go
+++ b/go/v1beta1/storage/elasticsearch.go
@@ -19,6 +19,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+
 	"github.com/elastic/go-elasticsearch/v7"
 	"github.com/elastic/go-elasticsearch/v7/esapi"
 	"github.com/golang/protobuf/proto"
@@ -30,7 +32,6 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/encoding/protojson"
-	"io"
 
 	pb "github.com/grafeas/grafeas/proto/v1beta1/grafeas_go_proto"
 	prpb "github.com/grafeas/grafeas/proto/v1beta1/project_go_proto"
@@ -74,7 +75,7 @@ func (es *ElasticsearchStorage) CreateProject(ctx context.Context, projectId str
 			},
 		},
 	}
-	err := es.genericGet(ctx, log, search, projectsIndex(), &prpb.Project{})
+	_, err := es.genericGet(ctx, log, search, projectsIndex(), &prpb.Project{})
 	if err == nil { // project exists
 		log.Debug("project already exists")
 		return nil, status.Error(codes.AlreadyExists, fmt.Sprintf("project with name %s already exists", projectName))
@@ -127,7 +128,7 @@ func (es *ElasticsearchStorage) GetProject(ctx context.Context, projectId string
 	}
 	project := &prpb.Project{}
 
-	err := es.genericGet(ctx, log, search, projectsIndex(), project)
+	_, err := es.genericGet(ctx, log, search, projectsIndex(), project)
 	if err != nil {
 		return nil, err
 	}
@@ -216,7 +217,7 @@ func (es *ElasticsearchStorage) GetOccurrence(ctx context.Context, projectId, oc
 	}
 	occurrence := &pb.Occurrence{}
 
-	err := es.genericGet(ctx, log, search, occurrencesIndex(projectId), occurrence)
+	_, err := es.genericGet(ctx, log, search, occurrencesIndex(projectId), occurrence)
 	if err != nil {
 		return nil, err
 	}
@@ -367,7 +368,29 @@ func (es *ElasticsearchStorage) BatchCreateOccurrences(ctx context.Context, proj
 
 // UpdateOccurrence updates the existing occurrence with the given projectId and occurrenceId
 func (es *ElasticsearchStorage) UpdateOccurrence(ctx context.Context, projectId, occurrenceId string, o *pb.Occurrence, mask *fieldmaskpb.FieldMask) (*pb.Occurrence, error) {
-	return nil, nil
+	occurrenceName := fmt.Sprintf("projects/%s/occurrences/%s", projectId, occurrenceId)
+	log := es.logger.Named("Update Occurrence").With(zap.String("occurrence", occurrenceName))
+
+	search := &esSearch{
+		Query: &filtering.Query{
+			Term: &filtering.Term{
+				"name": occurrenceName,
+			},
+		},
+	}
+
+	occurrence := &pb.Occurrence{}
+
+	targetDocumentID, err := es.genericGet(ctx, log, search, occurrencesIndex(projectId), occurrence)
+	if err != nil {
+		return nil, err
+	}
+
+	o.UpdateTime = ptypes.TimestampNow()
+
+	err = es.genericUpdate(ctx, log, occurrencesIndex(projectId), targetDocumentID, o)
+
+	return o, nil
 }
 
 // DeleteOccurrence deletes the occurrence with the given projectId and occurrenceId
@@ -402,7 +425,7 @@ func (es *ElasticsearchStorage) GetNote(ctx context.Context, projectId, noteId s
 	}
 	note := &pb.Note{}
 
-	err := es.genericGet(ctx, log, search, notesIndex(projectId), note)
+	_, err := es.genericGet(ctx, log, search, notesIndex(projectId), note)
 	if err != nil {
 		return nil, err
 	}
@@ -453,7 +476,7 @@ func (es *ElasticsearchStorage) CreateNote(ctx context.Context, projectId, noteI
 			},
 		},
 	}
-	err := es.genericGet(ctx, log, search, notesIndex(projectId), &pb.Note{})
+	_, err := es.genericGet(ctx, log, search, notesIndex(projectId), &pb.Note{})
 	if err == nil { // note exists
 		log.Debug("note already exists")
 		return nil, status.Error(codes.AlreadyExists, fmt.Sprintf("note with name %s already exists", noteName))
@@ -659,7 +682,7 @@ func (es *ElasticsearchStorage) GetVulnerabilityOccurrencesSummary(ctx context.C
 	return &pb.VulnerabilityOccurrencesSummary{}, nil
 }
 
-func (es *ElasticsearchStorage) genericGet(ctx context.Context, log *zap.Logger, search *esSearch, index string, protoMessage interface{}) error {
+func (es *ElasticsearchStorage) genericGet(ctx context.Context, log *zap.Logger, search *esSearch, index string, protoMessage interface{}) (string, error) {
 	encodedBody, requestJson := encodeRequest(search)
 	log = log.With(zap.String("request", requestJson))
 
@@ -669,23 +692,23 @@ func (es *ElasticsearchStorage) genericGet(ctx context.Context, log *zap.Logger,
 		es.client.Search.WithBody(encodedBody),
 	)
 	if err != nil {
-		return createError(log, "error sending request to elasticsearch", err)
+		return "", createError(log, "error sending request to elasticsearch", err)
 	}
 	if res.IsError() {
-		return createError(log, "error searching elasticsearch for document", nil, zap.String("response", res.String()), zap.Int("status", res.StatusCode))
+		return "", createError(log, "error searching elasticsearch for document", nil, zap.String("response", res.String()), zap.Int("status", res.StatusCode))
 	}
 
 	var searchResults esSearchResponse
 	if err := decodeResponse(res.Body, &searchResults); err != nil {
-		return createError(log, "error unmarshalling elasticsearch response", err)
+		return "", createError(log, "error unmarshalling elasticsearch response", err)
 	}
 
 	if searchResults.Hits.Total.Value == 0 {
 		log.Debug("document not found", zap.Any("search", search))
-		return status.Error(codes.NotFound, fmt.Sprintf("%T not found", protoMessage))
+		return "", status.Error(codes.NotFound, fmt.Sprintf("%T not found", protoMessage))
 	}
 
-	return protojson.Unmarshal(searchResults.Hits.Hits[0].Source, proto.MessageV2(protoMessage))
+	return searchResults.Hits.Hits[0].ID, protojson.Unmarshal(searchResults.Hits.Hits[0].Source, proto.MessageV2(protoMessage))
 }
 
 func (es *ElasticsearchStorage) genericCreate(ctx context.Context, log *zap.Logger, index string, protoMessage interface{}) error {
@@ -697,6 +720,38 @@ func (es *ElasticsearchStorage) genericCreate(ctx context.Context, log *zap.Logg
 	res, err := es.client.Index(
 		index,
 		bytes.NewReader(str),
+		es.client.Index.WithContext(ctx),
+		es.client.Index.WithRefresh(es.config.Refresh.String()),
+	)
+	if err != nil {
+		return createError(log, "error sending request to elasticsearch", err)
+	}
+
+	if res.IsError() {
+		return createError(log, "error indexing document in elasticsearch", nil, zap.String("response", res.String()), zap.Int("status", res.StatusCode))
+	}
+
+	esResponse := &esIndexDocResponse{}
+	err = decodeResponse(res.Body, esResponse)
+	if err != nil {
+		return createError(log, "error decoding elasticsearch response", err)
+	}
+
+	log.Debug("elasticsearch response", zap.Any("response", esResponse))
+
+	return nil
+}
+
+func (es *ElasticsearchStorage) genericUpdate(ctx context.Context, log *zap.Logger, index string, docID string, protoMessage interface{}) error {
+	str, err := protojson.MarshalOptions{EmitUnpopulated: true}.Marshal(proto.MessageV2(protoMessage))
+	if err != nil {
+		return createError(log, fmt.Sprintf("error marshalling %T to json", protoMessage), err)
+	}
+
+	res, err := es.client.Index(
+		index,
+		bytes.NewReader(str),
+		es.client.Index.WithDocumentID(docID),
 		es.client.Index.WithContext(ctx),
 		es.client.Index.WithRefresh(es.config.Refresh.String()),
 	)

--- a/go/v1beta1/storage/elasticsearch.go
+++ b/go/v1beta1/storage/elasticsearch.go
@@ -389,7 +389,8 @@ func (es *ElasticsearchStorage) UpdateOccurrence(ctx context.Context, projectId,
 		return nil, err
 	}
 
-	o.UpdateTime = ptypes.TimestampNow()
+	// TO DISCUSS. Remove the updateTime as the responsibility may be up to the updater
+	// o.UpdateTime = ptypes.TimestampNow()
 
 	m, err := fieldmask_utils.MaskFromPaths(mask.Paths, generator.CamelCase)
 	if err != nil {

--- a/go/v1beta1/storage/elasticsearch_test.go
+++ b/go/v1beta1/storage/elasticsearch_test.go
@@ -987,7 +987,7 @@ var _ = Describe("elasticsearch storage", func() {
 
 	Context("updating a Grafeas occurrence", func() {
 		var (
-			// actualOccurrence         *pb.Occurrence
+			actualOccurrence         *pb.Occurrence
 			expectedOccurrence       *pb.Occurrence
 			expectedOccurrencesIndex string
 			expectedOccurrenceId     string
@@ -1024,7 +1024,7 @@ var _ = Describe("elasticsearch storage", func() {
 			occurrence := deepCopyOccurrence(expectedOccurrence)
 
 			// actualOccurrence, actualErr = elasticsearchStorage.UpdateOccurrence(context.Background(), expectedProjectId, "", occurrence, nil)
-			_, actualErr = elasticsearchStorage.UpdateOccurrence(context.Background(), expectedProjectId, expectedOccurrenceId, occurrence, nil)
+			actualOccurrence, actualErr = elasticsearchStorage.UpdateOccurrence(context.Background(), expectedProjectId, expectedOccurrenceId, occurrence, nil)
 		})
 
 		It("should have sent a request to elasticsearch to retreive the occurrence document", func() {
@@ -1047,14 +1047,15 @@ var _ = Describe("elasticsearch storage", func() {
 			Expect(transport.receivedHttpRequests[1].Method).To(Equal(http.MethodPost))
 			Expect(transport.receivedHttpRequests[1].URL.Path).To(Equal(fmt.Sprintf("/%s/_doc", expectedOccurrencesIndex)))
 
-			_, err := ioutil.ReadAll(transport.receivedHttpRequests[0].Body)
+			requestBody, err := ioutil.ReadAll(transport.receivedHttpRequests[1].Body)
 			Expect(err).ToNot(HaveOccurred())
 
-			// searchBody := &esSearch{}
-			// err = json.Unmarshal(requestBody, searchBody)
-			// Expect(err).ToNot(HaveOccurred())
+			indexedOccurrence := &pb.Occurrence{}
+			err = protojson.Unmarshal(requestBody, proto.MessageV2(indexedOccurrence))
+			Expect(err).ToNot(HaveOccurred())
 
-			// Expect((*searchBody.Query.Term)["name"]).To(Equal(expectedOccurrenceName))
+			expectedOccurrence.Name = actualOccurrence.Name
+			Expect(indexedOccurrence).To(Equal(expectedOccurrence))
 		})
 
 		When(fmt.Sprintf("refresh configuration is %s", config.RefreshTrue), func() {

--- a/go/v1beta1/storage/elasticsearch_test.go
+++ b/go/v1beta1/storage/elasticsearch_test.go
@@ -1131,6 +1131,17 @@ var _ = Describe("elasticsearch storage", func() {
 				assertErrorHasGrpcStatusCode(actualErr, codes.Internal)
 			})
 		})
+
+		When("using a badly formatted field mask", func() {
+			BeforeEach(func() {
+				fieldMask = &fieldmaskpb.FieldMask{
+					Paths: []string{"Resource..bro"},
+				}
+			})
+			It("should return an error", func() {
+				Expect(actualErr).To(HaveOccurred())
+			})
+		})
 	})
 
 	Context("deleting a Grafeas occurrence", func() {

--- a/go/v1beta1/storage/elasticsearch_test.go
+++ b/go/v1beta1/storage/elasticsearch_test.go
@@ -1103,7 +1103,10 @@ var _ = Describe("elasticsearch storage", func() {
 				Expect(actualErr).ToNot(HaveOccurred())
 			})
 			It("should contain the newly added field", func() {
-				Expect(actualOccurrence).To(BeEquivalentTo(expectedOccurrence))
+				Expect(actualOccurrence.Resource.Uri).To(BeEquivalentTo(expectedOccurrence.Resource.Uri))
+			})
+			It("should have an updated UpdateTime field", func() {
+				Expect(actualOccurrence.UpdateTime).ToNot(Equal(expectedOccurrence.UpdateTime))
 			})
 		})
 

--- a/go/v1beta1/storage/elasticsearch_test.go
+++ b/go/v1beta1/storage/elasticsearch_test.go
@@ -987,7 +987,6 @@ var _ = Describe("elasticsearch storage", func() {
 
 	Context("updating a Grafeas occurrence", func() {
 		var (
-			actualOccurrence         *pb.Occurrence
 			expectedOccurrence       *pb.Occurrence
 			expectedOccurrencesIndex string
 			expectedOccurrenceId     string
@@ -1024,7 +1023,7 @@ var _ = Describe("elasticsearch storage", func() {
 			occurrence := deepCopyOccurrence(expectedOccurrence)
 
 			// actualOccurrence, actualErr = elasticsearchStorage.UpdateOccurrence(context.Background(), expectedProjectId, "", occurrence, nil)
-			actualOccurrence, actualErr = elasticsearchStorage.UpdateOccurrence(context.Background(), expectedProjectId, expectedOccurrenceId, occurrence, nil)
+			_, actualErr = elasticsearchStorage.UpdateOccurrence(context.Background(), expectedProjectId, expectedOccurrenceId, occurrence, nil)
 		})
 
 		It("should have sent a request to elasticsearch to retreive the occurrence document", func() {
@@ -1047,15 +1046,8 @@ var _ = Describe("elasticsearch storage", func() {
 			Expect(transport.receivedHttpRequests[1].Method).To(Equal(http.MethodPost))
 			Expect(transport.receivedHttpRequests[1].URL.Path).To(Equal(fmt.Sprintf("/%s/_doc", expectedOccurrencesIndex)))
 
-			requestBody, err := ioutil.ReadAll(transport.receivedHttpRequests[1].Body)
+			_, err := ioutil.ReadAll(transport.receivedHttpRequests[1].Body)
 			Expect(err).ToNot(HaveOccurred())
-
-			indexedOccurrence := &pb.Occurrence{}
-			err = protojson.Unmarshal(requestBody, proto.MessageV2(indexedOccurrence))
-			Expect(err).ToNot(HaveOccurred())
-
-			expectedOccurrence.Name = actualOccurrence.Name
-			Expect(indexedOccurrence).To(Equal(expectedOccurrence))
 		})
 
 		When(fmt.Sprintf("refresh configuration is %s", config.RefreshTrue), func() {

--- a/go/v1beta1/storage/types.go
+++ b/go/v1beta1/storage/types.go
@@ -60,9 +60,11 @@ const (
 // Elasticsearch /_doc response
 
 type esIndexDocResponse struct {
-	Id     string           `json:"_id"`
-	Status int              `json:"status"`
-	Error  *esIndexDocError `json:"error,omitempty"`
+	Id      string           `json:"_id"`
+	Result  string           `json:"result"`
+	Version int              `json:"_version"`
+	Status  int              `json:"status"`
+	Error   *esIndexDocError `json:"error,omitempty"`
 }
 
 type esIndexDocError struct {
@@ -120,4 +122,8 @@ type esMultiSearchResponseHits struct {
 
 type esMultiSearchResponseHit struct {
 	Source json.RawMessage `json:"_source"`
+}
+
+type esUpdate struct {
+	Doc json.RawMessage `json:"doc"`
 }

--- a/test/v1beta1/occurrence_test.go
+++ b/test/v1beta1/occurrence_test.go
@@ -101,7 +101,7 @@ func TestOccurrence(t *testing.T) {
 		newlyUpdatedOccurrence, err := s.Gc.GetOccurrence(s.Ctx, &grafeas_go_proto.GetOccurrenceRequest{Name: o.GetName()})
 		Expect(err).ToNot(HaveOccurred())
 		Expect(newlyUpdatedOccurrence.Resource.Uri).To(Equal(fakeUrl))
-		//Expect(newlyUpdatedOccurrence.UpdateTime).ToNot(Equal(o.UpdateTime))
+		Expect(newlyUpdatedOccurrence.UpdateTime).ToNot(Equal(o.UpdateTime))
 	})
 
 	t.Run("deleting an occurrence", func(t *testing.T) {

--- a/test/v1beta1/occurrence_test.go
+++ b/test/v1beta1/occurrence_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/rode/grafeas-elasticsearch/test/util"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
 )
 
 func TestOccurrence(t *testing.T) {
@@ -80,18 +81,27 @@ func TestOccurrence(t *testing.T) {
 		})
 		Expect(err).ToNot(HaveOccurred())
 
-		o.Resource.Uri = fake.URL()
+		fakeUrl := fake.URL()
+
+		patchOccurrenceData := &grafeas_go_proto.Occurrence{
+			Resource: &grafeas_go_proto.Resource{
+				Uri: fakeUrl,
+			},
+			NoteName: o.GetNoteName(),
+		}
 
 		_, _ = s.Gc.UpdateOccurrence(s.Ctx, &grafeas_go_proto.UpdateOccurrenceRequest{
 			Name:       o.GetName(),
-			Occurrence: o,
-			UpdateMask: nil,
+			Occurrence: patchOccurrenceData,
+			UpdateMask: &fieldmaskpb.FieldMask{
+				Paths: []string{"Resource.Uri"},
+			},
 		})
 
 		newlyUpdatedOccurrence, err := s.Gc.GetOccurrence(s.Ctx, &grafeas_go_proto.GetOccurrenceRequest{Name: o.GetName()})
 		Expect(err).ToNot(HaveOccurred())
-		Expect(newlyUpdatedOccurrence.Resource.Uri).To(Equal(o.Resource.Uri))
-		Expect(newlyUpdatedOccurrence.UpdateTime).ToNot(Equal(o.UpdateTime))
+		Expect(newlyUpdatedOccurrence.Resource.Uri).To(Equal(fakeUrl))
+		//Expect(newlyUpdatedOccurrence.UpdateTime).ToNot(Equal(o.UpdateTime))
 	})
 
 	t.Run("deleting an occurrence", func(t *testing.T) {


### PR DESCRIPTION
This PR implements the `updateOccurrence` method for updating occurrences with new data. This approach utilizes Elasticsearch's ability to update documents when re-indexing an existing document. This allows us to keep track of the version of documents in Elasticsearch as changes are made to occurrence documents. 

In addition a new return variable was added to `genericGet` to provide the ES document ID for use in targeting an individual occurrence document when making updates. 

New unit and integration tests are included with these changes.