### PR TITLE
add pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ currently implemented features, along with the features that have not been imple
   - [x] `.startsWith` function (ex: `"resource.uri".startsWith("gcr.io")`)
   - [x] `.contains` function (ex: `"resource.uri".contains("alpine")`)
   - [ ] `.endsWith` function
-- [ ] Pagination
+- [x] Pagination
 - [ ] Elasticsearch config
   - [x] URL
   - [x] Index refresh behavior

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.15
 require (
 	github.com/Jeffail/gabs/v2 v2.6.0
 	github.com/brianvoe/gofakeit/v6 v6.0.0
-	github.com/elastic/go-elasticsearch/v7 v7.5.1-0.20201104130636-152864b47d96
+	github.com/elastic/go-elasticsearch/v7 v7.10.0
 	github.com/golang/mock v1.4.4
 	github.com/golang/protobuf v1.4.2
 	github.com/google/cel-go v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -54,8 +54,8 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/dchest/safefile v0.0.0-20151022103144-855e8d98f185/go.mod h1:cFRxtTwTOJkz2x3rQUNCYKWC93yP1VKjR8NUhqFxZNU=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
-github.com/elastic/go-elasticsearch/v7 v7.5.1-0.20201104130636-152864b47d96 h1:lYCctiMAT/uTRLTwPJnGoBeGKdgbmbKIN++ekoUrjuE=
-github.com/elastic/go-elasticsearch/v7 v7.5.1-0.20201104130636-152864b47d96/go.mod h1:OJ4wdbtDNk5g503kvlHLyErCgQwwzmDtaFC4XyOxXA4=
+github.com/elastic/go-elasticsearch/v7 v7.10.0 h1:vYRwqgFM46ZUHFMRdvKr+y1WA4ehJO6WqAGV9Btbl2o=
+github.com/elastic/go-elasticsearch/v7 v7.10.0/go.mod h1:OJ4wdbtDNk5g503kvlHLyErCgQwwzmDtaFC4XyOxXA4=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=

--- a/go/v1beta1/storage/elasticsearch.go
+++ b/go/v1beta1/storage/elasticsearch.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/elastic/go-elasticsearch/v7/esapi"
 	"github.com/rode/grafeas-elasticsearch/go/v1beta1/storage/migration"
 
 	"github.com/elastic/go-elasticsearch/v7"
@@ -163,7 +164,7 @@ func (es *ElasticsearchStorage) ListProjects(ctx context.Context, filter string,
 	var projects []*prpb.Project
 	log := es.logger.Named("ListProjects")
 
-	res, err := es.genericList(ctx, log, es.indexManager.ProjectsAlias(), filter, false)
+	res, nextPageToken, err := es.genericList(ctx, log, es.indexManager.ProjectsAlias(), filter, false, pageToken, int32(pageSize))
 	if err != nil {
 		return nil, "", err
 	}
@@ -183,7 +184,7 @@ func (es *ElasticsearchStorage) ListProjects(ctx context.Context, filter string,
 		projects = append(projects, project)
 	}
 
-	return projects, "", nil
+	return projects, nextPageToken, nil
 }
 
 // DeleteProject deletes the project with the given projectId from Elasticsearch
@@ -252,22 +253,9 @@ func (es *ElasticsearchStorage) ListOccurrences(ctx context.Context, projectId, 
 	projectName := fmt.Sprintf("projects/%s", projectId)
 	log := es.logger.Named("ListOccurrences").With(zap.String("project", projectName))
 
-	var (
-		res           *esutil.EsSearchResponseHits
-		nextPageToken string
-		err           error
-	)
-
-	if pageToken != "" || pageSize != 0 {
-		res, nextPageToken, err = es.genericListWithPagination(ctx, log, es.indexManager.OccurrencesAlias(projectId), filter, true, pageToken, int(pageSize))
-		if err != nil {
-			return nil, "", err
-		}
-	} else {
-		res, err = es.genericList(ctx, log, es.indexManager.OccurrencesAlias(projectId), filter, true)
-		if err != nil {
-			return nil, "", err
-		}
+	res, nextPageToken, err := es.genericList(ctx, log, es.indexManager.OccurrencesAlias(projectId), filter, true, pageToken, pageSize)
+	if err != nil {
+		return nil, "", err
 	}
 
 	var occurrences []*pb.Occurrence
@@ -500,7 +488,7 @@ func (es *ElasticsearchStorage) ListNotes(ctx context.Context, projectId, filter
 	projectName := fmt.Sprintf("projects/%s", projectId)
 	log := es.logger.Named("ListNotes").With(zap.String("project", projectName))
 
-	res, err := es.genericList(ctx, log, es.indexManager.NotesAlias(projectId), filter, true)
+	res, nextPageToken, err := es.genericList(ctx, log, es.indexManager.NotesAlias(projectId), filter, true, pageToken, pageSize)
 	if err != nil {
 		return nil, "", err
 	}
@@ -521,7 +509,7 @@ func (es *ElasticsearchStorage) ListNotes(ctx context.Context, projectId, filter
 		notes = append(notes, note)
 	}
 
-	return notes, "", nil
+	return notes, nextPageToken, nil
 }
 
 // CreateNote adds the specified note
@@ -880,99 +868,8 @@ func (es *ElasticsearchStorage) genericDelete(ctx context.Context, log *zap.Logg
 	return nil
 }
 
-func (es *ElasticsearchStorage) genericList(ctx context.Context, log *zap.Logger, index, filter string, sort bool) (*esutil.EsSearchResponseHits, error) {
+func (es *ElasticsearchStorage) genericList(ctx context.Context, log *zap.Logger, index, filter string, sort bool, pageToken string, pageSize int32) (*esutil.EsSearchResponseHits, string, error) {
 	body := &esutil.EsSearch{}
-	if filter != "" {
-		log = log.With(zap.String("filter", filter))
-		filterQuery, err := es.filterer.ParseExpression(filter)
-		if err != nil {
-			return nil, createError(log, "error while parsing filter expression", err)
-		}
-
-		body.Query = filterQuery
-	}
-
-	if sort {
-		body.Sort = map[string]esutil.EsSortOrder{
-			sortField: esutil.EsSortOrderDecending,
-		}
-	}
-
-	encodedBody, requestJson := esutil.EncodeRequest(body)
-	log = log.With(zap.String("request", requestJson))
-	log.Debug("performing search")
-
-	res, err := es.client.Search(
-		es.client.Search.WithContext(ctx),
-		es.client.Search.WithIndex(index),
-		es.client.Search.WithBody(encodedBody),
-		es.client.Search.WithSize(grafeasMaxPageSize),
-	)
-	if err != nil {
-		return nil, createError(log, "error sending request to elasticsearch", err)
-	}
-	if res.IsError() {
-		return nil, createError(log, "unexpected response from elasticsearch", nil, zap.String("response", res.String()), zap.Int("status", res.StatusCode))
-	}
-
-	var searchResults esutil.EsSearchResponse
-	if err := esutil.DecodeResponse(res.Body, &searchResults); err != nil {
-		return nil, createError(log, "error decoding elasticsearch response", err)
-	}
-
-	return searchResults.Hits, nil
-}
-
-// genericListWithPagination should be invoked in place of genericList whenever a pageSize or pageToken is specified
-func (es *ElasticsearchStorage) genericListWithPagination(ctx context.Context, log *zap.Logger, index, filter string, sort bool, pageToken string, pageSize int) (*esutil.EsSearchResponseHits, string, error) {
-	// if we're using pagination with a page size of zero, this will always return zero results
-	// fail here, but we could revisit this and decide to default the page size to 1000 instead
-	if pageToken != "" && pageSize == 0 {
-		return nil, "", createError(log, "expected a page size to be included with a page token", nil)
-	}
-	log = log.With(zap.String("pageToken", pageToken), zap.Int("pageSize", pageSize))
-
-	var (
-		pit  string
-		from int
-		err  error
-	)
-
-	// if no pageToken is specified, we need to create a new PIT
-	if pageToken == "" {
-		res, err := es.client.OpenPointInTime(
-			es.client.OpenPointInTime.WithContext(ctx),
-			es.client.OpenPointInTime.WithIndex(index),
-			es.client.OpenPointInTime.WithKeepAlive(pitKeepAlive),
-		)
-		if err != nil {
-			return nil, "", createError(log, "error sending request to elasticsearch", err)
-		}
-		if res.IsError() {
-			return nil, "", createError(log, "unexpected response from elasticsearch", nil, zap.String("response", res.String()), zap.Int("status", res.StatusCode))
-		}
-
-		var pitResponse esutil.ESPitResponse
-		if err = esutil.DecodeResponse(res.Body, &pitResponse); err != nil {
-			return nil, "", createError(log, "error decoding elasticsearch response", err)
-		}
-
-		pit = pitResponse.Id
-		from = 0
-	} else {
-		// get the PIT from the provided pageToken
-		pit, from, err = esutil.ParsePageToken(pageToken)
-		if err != nil {
-			return nil, "", createError(log, "error parsing page token", err)
-		}
-	}
-
-	body := &esutil.EsSearch{
-		Pit: &esutil.EsSearchPit{
-			Id:        pit,
-			KeepAlive: pitKeepAlive,
-		},
-	}
 	if filter != "" {
 		log = log.With(zap.String("filter", filter))
 		filterQuery, err := es.filterer.ParseExpression(filter)
@@ -989,16 +886,32 @@ func (es *ElasticsearchStorage) genericListWithPagination(ctx context.Context, l
 		}
 	}
 
+	searchOptions := []func(*esapi.SearchRequest){
+		es.client.Search.WithContext(ctx),
+	}
+
+	var nextPageToken string
+	if pageToken != "" || pageSize != 0 { // handle pagination
+		next, extraSearchOptions, err := es.handlePagination(ctx, log, body, index, pageToken, pageSize)
+		if err != nil {
+			return nil, "", createError(log, "error while handling pagination", err)
+		}
+
+		nextPageToken = next
+		searchOptions = append(searchOptions, extraSearchOptions...)
+	} else {
+		searchOptions = append(searchOptions,
+			es.client.Search.WithIndex(index),
+			es.client.Search.WithSize(grafeasMaxPageSize),
+		)
+	}
+
 	encodedBody, requestJson := esutil.EncodeRequest(body)
 	log = log.With(zap.String("request", requestJson))
 	log.Debug("performing search")
 
-	// index is omitted here because searching with PIT takes care of that
 	res, err := es.client.Search(
-		es.client.Search.WithContext(ctx),
-		es.client.Search.WithBody(encodedBody),
-		es.client.Search.WithSize(pageSize),
-		es.client.Search.WithFrom(from),
+		append(searchOptions, es.client.Search.WithBody(encodedBody))...,
 	)
 	if err != nil {
 		return nil, "", createError(log, "error sending request to elasticsearch", err)
@@ -1012,7 +925,56 @@ func (es *ElasticsearchStorage) genericListWithPagination(ctx context.Context, l
 		return nil, "", createError(log, "error decoding elasticsearch response", err)
 	}
 
-	return searchResults.Hits, esutil.CreatePageToken(searchResults.PitId, from+pageSize), nil
+	return searchResults.Hits, nextPageToken, nil
+}
+
+func (es *ElasticsearchStorage) handlePagination(ctx context.Context, log *zap.Logger, body *esutil.EsSearch, index, pageToken string, pageSize int32) (string, []func(*esapi.SearchRequest), error) {
+	log = log.With(zap.String("pageToken", pageToken), zap.Int32("pageSize", pageSize))
+
+	var (
+		pit  string
+		from int
+		err  error
+	)
+
+	// if no pageToken is specified, we need to create a new PIT
+	if pageToken == "" {
+		res, err := es.client.OpenPointInTime(
+			es.client.OpenPointInTime.WithContext(ctx),
+			es.client.OpenPointInTime.WithIndex(index),
+			es.client.OpenPointInTime.WithKeepAlive(pitKeepAlive),
+		)
+		if err != nil {
+			return "", nil, createError(log, "error sending request to elasticsearch", err)
+		}
+		if res.IsError() {
+			return "", nil, createError(log, "unexpected response from elasticsearch", nil, zap.String("response", res.String()), zap.Int("status", res.StatusCode))
+		}
+
+		var pitResponse esutil.ESPitResponse
+		if err = esutil.DecodeResponse(res.Body, &pitResponse); err != nil {
+			return "", nil, createError(log, "error decoding elasticsearch response", err)
+		}
+
+		pit = pitResponse.Id
+		from = 0
+	} else {
+		// get the PIT from the provided pageToken
+		pit, from, err = esutil.ParsePageToken(pageToken)
+		if err != nil {
+			return "", nil, createError(log, "error parsing page token", err)
+		}
+	}
+
+	body.Pit = &esutil.EsSearchPit{
+		Id:        pit,
+		KeepAlive: pitKeepAlive,
+	}
+
+	return esutil.CreatePageToken(pit, from+int(pageSize)), []func(*esapi.SearchRequest){
+		es.client.Search.WithSize(int(pageSize)),
+		es.client.Search.WithFrom(from),
+	}, err
 }
 
 // createError is a helper function that allows you to easily log an error and return a gRPC formatted error.

--- a/go/v1beta1/storage/elasticsearch_test.go
+++ b/go/v1beta1/storage/elasticsearch_test.go
@@ -492,6 +492,162 @@ var _ = Describe("elasticsearch storage", func() {
 		})
 	})
 
+	Context("listing Grafeas projects with pagination", func() {
+		var (
+			actualErr           error
+			actualProjects      []*prpb.Project
+			actualNextPageToken string
+			expectedProjects    []*prpb.Project
+			expectedPageToken   string
+			expectedPageSize    int
+			expectedPitId       string
+			expectedFrom        int
+		)
+
+		BeforeEach(func() {
+			expectedProjects = generateTestProjects(fake.Number(2, 5))
+			expectedPageSize = fake.Number(10, 100)
+			expectedFrom = fake.Number(10, 100)
+			expectedPitId = fake.LetterN(20)
+			transport.PreparedHttpResponses = []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body: createProjectEsSearchResponse(
+						expectedProjects...,
+					),
+				},
+			}
+		})
+
+		JustBeforeEach(func() {
+			actualProjects, actualNextPageToken, actualErr = elasticsearchStorage.ListProjects(ctx, "", expectedPageSize, expectedPageToken)
+		})
+
+		When("a page token is not specified", func() {
+			BeforeEach(func() {
+				transport.PreparedHttpResponses = append([]*http.Response{
+					{
+						StatusCode: http.StatusOK,
+						Body: structToJsonBody(&esutil.ESPitResponse{
+							Id: expectedPitId,
+						}),
+					},
+				}, transport.PreparedHttpResponses...)
+			})
+
+			It("should create a PIT in elasticsearch", func() {
+				Expect(transport.ReceivedHttpRequests[0].URL.Path).To(Equal(fmt.Sprintf("/%s/_pit", expectedProjectAlias)))
+				Expect(transport.ReceivedHttpRequests[0].Method).To(Equal(http.MethodPost))
+				Expect(transport.ReceivedHttpRequests[0].URL.Query().Get("keep_alive")).To(Equal(pitKeepAlive))
+			})
+
+			It("should query elasticsearch for projects using the PIT id", func() {
+				Expect(transport.ReceivedHttpRequests[1].URL.Path).To(Equal("/_search"))
+				Expect(transport.ReceivedHttpRequests[1].Method).To(Equal(http.MethodGet))
+				Expect(transport.ReceivedHttpRequests[1].URL.Query().Get("size")).To(Equal(strconv.Itoa(expectedPageSize)))
+				Expect(transport.ReceivedHttpRequests[1].URL.Query().Get("from")).To(Equal(strconv.Itoa(0)))
+
+				requestBody, err := ioutil.ReadAll(transport.ReceivedHttpRequests[1].Body)
+				Expect(err).ToNot(HaveOccurred())
+
+				searchBody := &esutil.EsSearch{}
+				err = json.Unmarshal(requestBody, searchBody)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(searchBody.Query).To(BeNil())
+				Expect(searchBody.Pit.Id).To(Equal(expectedPitId))
+				Expect(searchBody.Pit.KeepAlive).To(Equal(pitKeepAlive))
+				Expect(searchBody.Pit.KeepAlive).To(Equal(pitKeepAlive))
+			})
+
+			It("should return the Grafeas project(s) and the new page token", func() {
+				Expect(actualProjects).ToNot(BeNil())
+				Expect(actualProjects).To(Equal(expectedProjects))
+				Expect(actualErr).ToNot(HaveOccurred())
+
+				pitId, from, err := esutil.ParsePageToken(actualNextPageToken)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(pitId).To(Equal(expectedPitId))
+				Expect(from).To(BeEquivalentTo(expectedPageSize))
+			})
+
+			When("creating a PIT in elasticsearch fails", func() {
+				BeforeEach(func() {
+					transport.PreparedHttpResponses[0].StatusCode = http.StatusInternalServerError
+				})
+
+				It("should return an error", func() {
+					assertErrorHasGrpcStatusCode(actualErr, codes.Internal)
+					Expect(actualNextPageToken).To(BeEmpty())
+				})
+			})
+		})
+
+		When("a valid page token is specified", func() {
+			BeforeEach(func() {
+				expectedPageToken = esutil.CreatePageToken(expectedPitId, expectedFrom)
+			})
+
+			It("should query elasticsearch for projects using the PIT id", func() {
+				Expect(transport.ReceivedHttpRequests[0].URL.Path).To(Equal("/_search"))
+				Expect(transport.ReceivedHttpRequests[0].Method).To(Equal(http.MethodGet))
+				Expect(transport.ReceivedHttpRequests[0].URL.Query().Get("size")).To(Equal(strconv.Itoa(expectedPageSize)))
+				Expect(transport.ReceivedHttpRequests[0].URL.Query().Get("from")).To(Equal(strconv.Itoa(expectedFrom)))
+
+				requestBody, err := ioutil.ReadAll(transport.ReceivedHttpRequests[0].Body)
+				Expect(err).ToNot(HaveOccurred())
+
+				searchBody := &esutil.EsSearch{}
+				err = json.Unmarshal(requestBody, searchBody)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(searchBody.Query).To(BeNil())
+				Expect(searchBody.Pit.Id).To(Equal(expectedPitId))
+				Expect(searchBody.Pit.KeepAlive).To(Equal(pitKeepAlive))
+				Expect(searchBody.Pit.KeepAlive).To(Equal(pitKeepAlive))
+			})
+
+			It("should return the Grafeas project(s) and the new page token", func() {
+				Expect(actualProjects).ToNot(BeNil())
+				Expect(actualProjects).To(Equal(expectedProjects))
+				Expect(actualErr).ToNot(HaveOccurred())
+
+				pitId, from, err := esutil.ParsePageToken(actualNextPageToken)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(pitId).To(Equal(expectedPitId))
+				Expect(from).To(BeEquivalentTo(expectedPageSize + expectedFrom))
+			})
+		})
+
+		When("an invalid page token is specified (bad format)", func() {
+			BeforeEach(func() {
+				expectedPageToken = fake.LetterN(50)
+			})
+
+			It("should not query elasticsearch", func() {
+				Expect(transport.ReceivedHttpRequests).To(HaveLen(0))
+			})
+
+			It("should return an error", func() {
+				assertErrorHasGrpcStatusCode(actualErr, codes.Internal)
+				Expect(actualNextPageToken).To(BeEmpty())
+			})
+		})
+
+		When("an invalid page token is specified (bad from)", func() {
+			BeforeEach(func() {
+				expectedPageToken = fmt.Sprintf("%sfoo", esutil.CreatePageToken(expectedPitId, expectedFrom))
+			})
+
+			It("should not query elasticsearch", func() {
+				Expect(transport.ReceivedHttpRequests).To(HaveLen(0))
+			})
+
+			It("should return an error", func() {
+				assertErrorHasGrpcStatusCode(actualErr, codes.Internal)
+				Expect(actualNextPageToken).To(BeEmpty())
+			})
+		})
+	})
+
 	Context("retrieving a Grafeas project", func() {
 		var (
 			actualErr     error
@@ -2382,7 +2538,7 @@ var _ = Describe("elasticsearch storage", func() {
 				Expect(transport.ReceivedHttpRequests[0].URL.Query().Get("keep_alive")).To(Equal(pitKeepAlive))
 			})
 
-			It("should query elasticsearch for occurrences using the PIT id", func() {
+			It("should query elasticsearch for notes using the PIT id", func() {
 				Expect(transport.ReceivedHttpRequests[1].URL.Path).To(Equal("/_search"))
 				Expect(transport.ReceivedHttpRequests[1].Method).To(Equal(http.MethodGet))
 				Expect(transport.ReceivedHttpRequests[1].URL.Query().Get("size")).To(Equal(strconv.Itoa(int(expectedPageSize))))
@@ -2401,7 +2557,7 @@ var _ = Describe("elasticsearch storage", func() {
 				Expect(searchBody.Pit.KeepAlive).To(Equal(pitKeepAlive))
 			})
 
-			It("should return the Grafeas occurrence(s) and the new page token", func() {
+			It("should return the Grafeas note(s) and the new page token", func() {
 				Expect(actualNotes).ToNot(BeNil())
 				Expect(actualNotes).To(Equal(expectedNotes))
 				Expect(actualErr).ToNot(HaveOccurred())
@@ -2429,7 +2585,7 @@ var _ = Describe("elasticsearch storage", func() {
 				expectedPageToken = esutil.CreatePageToken(expectedPitId, expectedFrom)
 			})
 
-			It("should query elasticsearch for occurrences using the PIT id", func() {
+			It("should query elasticsearch for notes using the PIT id", func() {
 				Expect(transport.ReceivedHttpRequests[0].URL.Path).To(Equal("/_search"))
 				Expect(transport.ReceivedHttpRequests[0].Method).To(Equal(http.MethodGet))
 				Expect(transport.ReceivedHttpRequests[0].URL.Query().Get("size")).To(Equal(strconv.Itoa(int(expectedPageSize))))

--- a/go/v1beta1/storage/elasticsearch_test.go
+++ b/go/v1beta1/storage/elasticsearch_test.go
@@ -1542,6 +1542,149 @@ var _ = Describe("elasticsearch storage", func() {
 		})
 	})
 
+	Context("listing Grafeas occurrences with pagination", func() {
+		var (
+			actualErr           error
+			actualOccurrences   []*pb.Occurrence
+			actualNextPageToken string
+			expectedOccurrences []*pb.Occurrence
+			expectedPageToken   string
+			expectedPageSize    int32
+			expectedPitId       string
+			expectedFrom        int
+		)
+
+		BeforeEach(func() {
+			expectedOccurrences = generateTestOccurrences(fake.Number(2, 5))
+			expectedPageSize = int32(fake.Number(10, 100))
+			expectedFrom = fake.Number(10, 100)
+			expectedPitId = fake.LetterN(20)
+			transport.PreparedHttpResponses = []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body: createOccurrenceEsSearchResponse(
+						expectedOccurrences...,
+					),
+				},
+			}
+		})
+
+		JustBeforeEach(func() {
+			actualOccurrences, actualNextPageToken, actualErr = elasticsearchStorage.ListOccurrences(ctx, expectedProjectId, "", expectedPageToken, expectedPageSize)
+		})
+
+		When("a page token is not specified", func() {
+			BeforeEach(func() {
+				transport.PreparedHttpResponses = append([]*http.Response{
+					{
+						StatusCode: http.StatusOK,
+						Body: structToJsonBody(&esutil.ESPitResponse{
+							Id: expectedPitId,
+						}),
+					},
+				}, transport.PreparedHttpResponses...)
+			})
+
+			It("should create a PIT in elasticsearch", func() {
+				Expect(transport.ReceivedHttpRequests[0].URL.Path).To(Equal(fmt.Sprintf("/%s/_pit", expectedOccurrencesAlias)))
+				Expect(transport.ReceivedHttpRequests[0].Method).To(Equal(http.MethodPost))
+				Expect(transport.ReceivedHttpRequests[0].URL.Query().Get("keep_alive")).To(Equal(pitKeepAlive))
+			})
+
+			It("should query elasticsearch for occurrences using the PIT id", func() {
+				Expect(transport.ReceivedHttpRequests[1].URL.Path).To(Equal("/_search"))
+				Expect(transport.ReceivedHttpRequests[1].Method).To(Equal(http.MethodGet))
+				Expect(transport.ReceivedHttpRequests[1].URL.Query().Get("size")).To(Equal(strconv.Itoa(int(expectedPageSize))))
+				Expect(transport.ReceivedHttpRequests[1].URL.Query().Get("from")).To(Equal(strconv.Itoa(0)))
+
+				requestBody, err := ioutil.ReadAll(transport.ReceivedHttpRequests[1].Body)
+				Expect(err).ToNot(HaveOccurred())
+
+				searchBody := &esutil.EsSearch{}
+				err = json.Unmarshal(requestBody, searchBody)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(searchBody.Query).To(BeNil())
+				Expect(searchBody.Sort[sortField]).To(Equal(esutil.EsSortOrderDecending))
+				Expect(searchBody.Pit.Id).To(Equal(expectedPitId))
+				Expect(searchBody.Pit.KeepAlive).To(Equal(pitKeepAlive))
+				Expect(searchBody.Pit.KeepAlive).To(Equal(pitKeepAlive))
+			})
+
+			It("should return the Grafeas occurrence(s) and the new page token", func() {
+				Expect(actualOccurrences).ToNot(BeNil())
+				Expect(actualOccurrences).To(Equal(expectedOccurrences))
+				Expect(actualErr).ToNot(HaveOccurred())
+
+				pitId, from, err := esutil.ParsePageToken(actualNextPageToken)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(pitId).To(Equal(expectedPitId))
+				Expect(from).To(BeEquivalentTo(expectedPageSize))
+			})
+
+			When("creating a PIT in elasticsearch fails", func() {
+				BeforeEach(func() {
+					transport.PreparedHttpResponses[0].StatusCode = http.StatusInternalServerError
+				})
+
+				It("should return an error", func() {
+					assertErrorHasGrpcStatusCode(actualErr, codes.Internal)
+					Expect(actualNextPageToken).To(BeEmpty())
+				})
+			})
+		})
+
+		When("a valid page token is specified", func() {
+			BeforeEach(func() {
+				expectedPageToken = esutil.CreatePageToken(expectedPitId, expectedFrom)
+			})
+
+			It("should query elasticsearch for occurrences using the PIT id", func() {
+				Expect(transport.ReceivedHttpRequests[0].URL.Path).To(Equal("/_search"))
+				Expect(transport.ReceivedHttpRequests[0].Method).To(Equal(http.MethodGet))
+				Expect(transport.ReceivedHttpRequests[0].URL.Query().Get("size")).To(Equal(strconv.Itoa(int(expectedPageSize))))
+				Expect(transport.ReceivedHttpRequests[0].URL.Query().Get("from")).To(Equal(strconv.Itoa(expectedFrom)))
+
+				requestBody, err := ioutil.ReadAll(transport.ReceivedHttpRequests[0].Body)
+				Expect(err).ToNot(HaveOccurred())
+
+				searchBody := &esutil.EsSearch{}
+				err = json.Unmarshal(requestBody, searchBody)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(searchBody.Query).To(BeNil())
+				Expect(searchBody.Sort[sortField]).To(Equal(esutil.EsSortOrderDecending))
+				Expect(searchBody.Pit.Id).To(Equal(expectedPitId))
+				Expect(searchBody.Pit.KeepAlive).To(Equal(pitKeepAlive))
+				Expect(searchBody.Pit.KeepAlive).To(Equal(pitKeepAlive))
+			})
+
+			It("should return the Grafeas occurrence(s) and the new page token", func() {
+				Expect(actualOccurrences).ToNot(BeNil())
+				Expect(actualOccurrences).To(Equal(expectedOccurrences))
+				Expect(actualErr).ToNot(HaveOccurred())
+
+				pitId, from, err := esutil.ParsePageToken(actualNextPageToken)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(pitId).To(Equal(expectedPitId))
+				Expect(from).To(BeEquivalentTo(int(expectedPageSize) + expectedFrom))
+			})
+		})
+
+		When("an invalid page token is specified", func() {
+			BeforeEach(func() {
+				expectedPageToken = fake.LetterN(50)
+			})
+
+			It("should not query elasticsearch", func() {
+				Expect(transport.ReceivedHttpRequests).To(HaveLen(0))
+			})
+
+			It("should return an error", func() {
+				assertErrorHasGrpcStatusCode(actualErr, codes.Internal)
+				Expect(actualNextPageToken).To(BeEmpty())
+			})
+		})
+	})
+
 	Context("creating a new Grafeas note", func() {
 		var (
 			actualNote       *pb.Note

--- a/go/v1beta1/storage/elasticsearch_test.go
+++ b/go/v1beta1/storage/elasticsearch_test.go
@@ -1669,9 +1669,24 @@ var _ = Describe("elasticsearch storage", func() {
 			})
 		})
 
-		When("an invalid page token is specified", func() {
+		When("an invalid page token is specified (bad format)", func() {
 			BeforeEach(func() {
 				expectedPageToken = fake.LetterN(50)
+			})
+
+			It("should not query elasticsearch", func() {
+				Expect(transport.ReceivedHttpRequests).To(HaveLen(0))
+			})
+
+			It("should return an error", func() {
+				assertErrorHasGrpcStatusCode(actualErr, codes.Internal)
+				Expect(actualNextPageToken).To(BeEmpty())
+			})
+		})
+
+		When("an invalid page token is specified (bad from)", func() {
+			BeforeEach(func() {
+				expectedPageToken = fmt.Sprintf("%sfoo", esutil.CreatePageToken(expectedPitId, expectedFrom))
 			})
 
 			It("should not query elasticsearch", func() {

--- a/go/v1beta1/storage/esutil/pit.go
+++ b/go/v1beta1/storage/esutil/pit.go
@@ -1,3 +1,17 @@
+// Copyright 2021 The Rode Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package esutil
 
 import (

--- a/go/v1beta1/storage/esutil/pit.go
+++ b/go/v1beta1/storage/esutil/pit.go
@@ -1,0 +1,29 @@
+package esutil
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+const pageTokenSeparator = ":"
+
+func ParsePageToken(pageToken string) (string, int, error) {
+	parts := strings.Split(pageToken, pageTokenSeparator)
+
+	if len(parts) != 2 {
+		return "", 0, errors.New(fmt.Sprintf("error parsing page token, expected two parts split by %s, got %d", pageTokenSeparator, len(parts)))
+	}
+
+	from, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return "", 0, err
+	}
+
+	return parts[0], from, nil
+}
+
+func CreatePageToken(pit string, from int) string {
+	return fmt.Sprintf("%s:%s", pit, strconv.Itoa(from))
+}

--- a/go/v1beta1/storage/esutil/types.go
+++ b/go/v1beta1/storage/esutil/types.go
@@ -22,8 +22,9 @@ import (
 // Elasticsearch /_search response
 
 type EsSearchResponse struct {
-	Took int                   `json:"took"`
-	Hits *EsSearchResponseHits `json:"hits"`
+	Took  int                   `json:"took"`
+	Hits  *EsSearchResponseHits `json:"hits"`
+	PitId string                `json:"pit_id"`
 }
 
 type EsSearchResponseHits struct {
@@ -47,7 +48,8 @@ type EsSearchResponseHit struct {
 type EsSearch struct {
 	Query    *filtering.Query       `json:"query,omitempty"`
 	Sort     map[string]EsSortOrder `json:"sort,omitempty"`
-	Collapse *EsCollapse            `json:"collapse,omitempty"`
+	Collapse *EsSearchCollapse      `json:"collapse,omitempty"`
+	Pit      *EsSearchPit           `json:"pit,omitempty"`
 }
 
 type EsSortOrder string
@@ -57,8 +59,13 @@ const (
 	EsSortOrderDecending EsSortOrder = "desc"
 )
 
-type EsCollapse struct {
+type EsSearchCollapse struct {
 	Field string `json:"field,omitempty"`
+}
+
+type EsSearchPit struct {
+	Id        string `json:"id"`
+	KeepAlive string `json:"keep_alive"`
 }
 
 // Elasticsearch /_doc response
@@ -195,6 +202,12 @@ type ESReindex struct {
 type ReindexFields struct {
 	Index  string `json:"index"`
 	OpType string `json:"op_type,omitempty"`
+}
+
+// Elasticsearch /$INDEX/_pit response
+
+type ESPitResponse struct {
+	Id string `json:"id"`
 }
 
 // Elasticsearch 400 error response

--- a/test/v1beta1/note_test.go
+++ b/test/v1beta1/note_test.go
@@ -168,6 +168,8 @@ func TestNote(t *testing.T) {
 				secondVulnerabilityNote = note
 			case "att1":
 				attestationNote = note
+			case "att2":
+				secondAttestationNote = note
 			}
 		}
 
@@ -176,7 +178,7 @@ func TestNote(t *testing.T) {
 				Parent: listProjectName,
 			})
 			Expect(err).ToNot(HaveOccurred())
-			Expect(res.Notes).To(HaveLen(5))
+			Expect(res.Notes).To(HaveLen(6))
 		})
 
 		t.Run("filters", func(t *testing.T) {
@@ -206,6 +208,7 @@ func TestNote(t *testing.T) {
 					filter: `kind=="ATTESTATION"`,
 					expected: []*grafeas_go_proto.Note{
 						attestationNote,
+						secondAttestationNote,
 					},
 				},
 				{
@@ -256,7 +259,7 @@ func TestNote(t *testing.T) {
 				Expect(res.Notes).To(HaveLen(pageSize))
 				Expect(res.NextPageToken).ToNot(BeEmpty())
 
-				// ensure we have not received these projects already
+				// ensure we have not received these notes already
 				for _, o := range res.Notes {
 					Expect(o).ToNot(BeElementOf(foundNotes))
 				}


### PR DESCRIPTION
this may or may not be a "breaking" change, depending on how we're currently using any of the `List` methods.  before this change, we would always return 1000 or less results for any `List` method.  now, [since there is apparently no way to use a `List` method in grafeas without pagination](https://github.com/grafeas/grafeas/blob/c188e86dabdab1e99f05772aee40940b1ca6e6e2/go/v1beta1/api/grafeas.go#L143-L156), you should always expect to receive results with a length of the provided `pageSize` (or less, if there happen to be less results).

I still kept a code path that won't do any of the pagination work if the provided `pageSize` is zero, but that is essentially dead code until the grafeas code that I linked above is changed in some way.  if we ever decide to propose that change upstream, we should be able to go back to the old behavior if we wish.