### PR TITLE
Omit empty on bulk query fragment types

### DIFF
--- a/go/v1beta1/storage/elasticsearch.go
+++ b/go/v1beta1/storage/elasticsearch.go
@@ -882,7 +882,7 @@ func (es *ElasticsearchStorage) genericList(ctx context.Context, log *zap.Logger
 
 	if sort {
 		body.Sort = map[string]esutil.EsSortOrder{
-			sortField: esutil.EsSortOrderDecending,
+			sortField: esutil.EsSortOrderDescending,
 		}
 	}
 

--- a/go/v1beta1/storage/elasticsearch_test.go
+++ b/go/v1beta1/storage/elasticsearch_test.go
@@ -556,7 +556,6 @@ var _ = Describe("elasticsearch storage", func() {
 				Expect(searchBody.Query).To(BeNil())
 				Expect(searchBody.Pit.Id).To(Equal(expectedPitId))
 				Expect(searchBody.Pit.KeepAlive).To(Equal(pitKeepAlive))
-				Expect(searchBody.Pit.KeepAlive).To(Equal(pitKeepAlive))
 			})
 
 			It("should return the Grafeas project(s) and the new page token", func() {
@@ -601,7 +600,6 @@ var _ = Describe("elasticsearch storage", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(searchBody.Query).To(BeNil())
 				Expect(searchBody.Pit.Id).To(Equal(expectedPitId))
-				Expect(searchBody.Pit.KeepAlive).To(Equal(pitKeepAlive))
 				Expect(searchBody.Pit.KeepAlive).To(Equal(pitKeepAlive))
 			})
 
@@ -1763,7 +1761,6 @@ var _ = Describe("elasticsearch storage", func() {
 				Expect(searchBody.Sort[sortField]).To(Equal(esutil.EsSortOrderDescending))
 				Expect(searchBody.Pit.Id).To(Equal(expectedPitId))
 				Expect(searchBody.Pit.KeepAlive).To(Equal(pitKeepAlive))
-				Expect(searchBody.Pit.KeepAlive).To(Equal(pitKeepAlive))
 			})
 
 			It("should return the Grafeas occurrence(s) and the new page token", func() {
@@ -1809,7 +1806,6 @@ var _ = Describe("elasticsearch storage", func() {
 				Expect(searchBody.Query).To(BeNil())
 				Expect(searchBody.Sort[sortField]).To(Equal(esutil.EsSortOrderDescending))
 				Expect(searchBody.Pit.Id).To(Equal(expectedPitId))
-				Expect(searchBody.Pit.KeepAlive).To(Equal(pitKeepAlive))
 				Expect(searchBody.Pit.KeepAlive).To(Equal(pitKeepAlive))
 			})
 
@@ -2554,7 +2550,6 @@ var _ = Describe("elasticsearch storage", func() {
 				Expect(searchBody.Sort[sortField]).To(Equal(esutil.EsSortOrderDescending))
 				Expect(searchBody.Pit.Id).To(Equal(expectedPitId))
 				Expect(searchBody.Pit.KeepAlive).To(Equal(pitKeepAlive))
-				Expect(searchBody.Pit.KeepAlive).To(Equal(pitKeepAlive))
 			})
 
 			It("should return the Grafeas note(s) and the new page token", func() {
@@ -2600,7 +2595,6 @@ var _ = Describe("elasticsearch storage", func() {
 				Expect(searchBody.Query).To(BeNil())
 				Expect(searchBody.Sort[sortField]).To(Equal(esutil.EsSortOrderDescending))
 				Expect(searchBody.Pit.Id).To(Equal(expectedPitId))
-				Expect(searchBody.Pit.KeepAlive).To(Equal(pitKeepAlive))
 				Expect(searchBody.Pit.KeepAlive).To(Equal(pitKeepAlive))
 			})
 

--- a/go/v1beta1/storage/elasticsearch_test.go
+++ b/go/v1beta1/storage/elasticsearch_test.go
@@ -1587,7 +1587,7 @@ var _ = Describe("elasticsearch storage", func() {
 			err = json.Unmarshal(requestBody, searchBody)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(searchBody.Query).To(BeNil())
-			Expect(searchBody.Sort[sortField]).To(Equal(esutil.EsSortOrderDecending))
+			Expect(searchBody.Sort[sortField]).To(Equal(esutil.EsSortOrderDescending))
 		})
 
 		When("a valid filter is specified", func() {
@@ -1760,7 +1760,7 @@ var _ = Describe("elasticsearch storage", func() {
 				err = json.Unmarshal(requestBody, searchBody)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(searchBody.Query).To(BeNil())
-				Expect(searchBody.Sort[sortField]).To(Equal(esutil.EsSortOrderDecending))
+				Expect(searchBody.Sort[sortField]).To(Equal(esutil.EsSortOrderDescending))
 				Expect(searchBody.Pit.Id).To(Equal(expectedPitId))
 				Expect(searchBody.Pit.KeepAlive).To(Equal(pitKeepAlive))
 				Expect(searchBody.Pit.KeepAlive).To(Equal(pitKeepAlive))
@@ -1807,7 +1807,7 @@ var _ = Describe("elasticsearch storage", func() {
 				err = json.Unmarshal(requestBody, searchBody)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(searchBody.Query).To(BeNil())
-				Expect(searchBody.Sort[sortField]).To(Equal(esutil.EsSortOrderDecending))
+				Expect(searchBody.Sort[sortField]).To(Equal(esutil.EsSortOrderDescending))
 				Expect(searchBody.Pit.Id).To(Equal(expectedPitId))
 				Expect(searchBody.Pit.KeepAlive).To(Equal(pitKeepAlive))
 				Expect(searchBody.Pit.KeepAlive).To(Equal(pitKeepAlive))
@@ -2378,7 +2378,7 @@ var _ = Describe("elasticsearch storage", func() {
 			err = json.Unmarshal(requestBody, searchBody)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(searchBody.Query).To(BeNil())
-			Expect(searchBody.Sort[sortField]).To(Equal(esutil.EsSortOrderDecending))
+			Expect(searchBody.Sort[sortField]).To(Equal(esutil.EsSortOrderDescending))
 		})
 
 		When("a valid filter is specified", func() {
@@ -2551,7 +2551,7 @@ var _ = Describe("elasticsearch storage", func() {
 				err = json.Unmarshal(requestBody, searchBody)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(searchBody.Query).To(BeNil())
-				Expect(searchBody.Sort[sortField]).To(Equal(esutil.EsSortOrderDecending))
+				Expect(searchBody.Sort[sortField]).To(Equal(esutil.EsSortOrderDescending))
 				Expect(searchBody.Pit.Id).To(Equal(expectedPitId))
 				Expect(searchBody.Pit.KeepAlive).To(Equal(pitKeepAlive))
 				Expect(searchBody.Pit.KeepAlive).To(Equal(pitKeepAlive))
@@ -2598,7 +2598,7 @@ var _ = Describe("elasticsearch storage", func() {
 				err = json.Unmarshal(requestBody, searchBody)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(searchBody.Query).To(BeNil())
-				Expect(searchBody.Sort[sortField]).To(Equal(esutil.EsSortOrderDecending))
+				Expect(searchBody.Sort[sortField]).To(Equal(esutil.EsSortOrderDescending))
 				Expect(searchBody.Pit.Id).To(Equal(expectedPitId))
 				Expect(searchBody.Pit.KeepAlive).To(Equal(pitKeepAlive))
 				Expect(searchBody.Pit.KeepAlive).To(Equal(pitKeepAlive))

--- a/go/v1beta1/storage/esutil/types.go
+++ b/go/v1beta1/storage/esutil/types.go
@@ -56,8 +56,8 @@ type EsSearch struct {
 type EsSortOrder string
 
 const (
-	EsSortOrderAscending EsSortOrder = "asc"
-	EsSortOrderDecending EsSortOrder = "desc"
+	EsSortOrderAscending  EsSortOrder = "asc"
+	EsSortOrderDescending EsSortOrder = "desc"
 )
 
 type EsSearchCollapse struct {
@@ -103,8 +103,8 @@ type EsDeleteResponse struct {
 // Elasticsearch /_bulk query fragments
 
 type EsBulkQueryFragment struct {
-	Index  *EsBulkQueryIndexFragment  `json:"index"`
-	Create *EsBulkQueryCreateFragment `json:"create"`
+	Index  *EsBulkQueryIndexFragment  `json:"index,omitempty"`
+	Create *EsBulkQueryCreateFragment `json:"create,omitempty"`
 }
 
 type EsBulkQueryIndexFragment struct {


### PR DESCRIPTION
Without `omitempty`, the `index` field is populated during a bulk create:

```
{"index":null,"create":{"_id":"foo"}}
{"name":"foo"}
```
which causes an error to be returned from Elasticsearch:

```
[400 Bad Request] {"error":{"root_cause":[{"type":"illegal_argument_exception","reason":"Malformed action/metadata line [1], expected START_OBJECT or END_OBJECT but found [VALUE_NULL]"}],"type":"illegal_argument_exception","reason":"Malformed action/metadata line [1], expected START_OBJECT or END_OBJECT but found [VALUE_NULL]"},"status":400}
```

Also renamed `EsSortOrderDecending` -> `EsSortOrderDescending` and removed some duplicate assertions. 
