### PR TITLE
Last page token on paginated requests should be an empty string

### DIFF
--- a/go/v1beta1/storage/elasticsearch.go
+++ b/go/v1beta1/storage/elasticsearch.go
@@ -44,7 +44,7 @@ import (
 
 const grafeasMaxPageSize = 1000
 const sortField = "createTime"
-const pitKeepAlive = "1m"
+const pitKeepAlive = "5m"
 
 type ElasticsearchStorage struct {
 	client                *elasticsearch.Client

--- a/go/v1beta1/storage/elasticsearch.go
+++ b/go/v1beta1/storage/elasticsearch.go
@@ -925,6 +925,17 @@ func (es *ElasticsearchStorage) genericList(ctx context.Context, log *zap.Logger
 		return nil, "", createError(log, "error decoding elasticsearch response", err)
 	}
 
+	if pageToken != "" || pageSize != 0 { // if request is paginated, check for last page
+		_, from, err := esutil.ParsePageToken(nextPageToken)
+		if err != nil {
+			return nil, "", createError(log, "error parsing page token", err)
+		}
+
+		if from >= searchResults.Hits.Total.Value {
+			nextPageToken = ""
+		}
+	}
+
 	return searchResults.Hits, nextPageToken, nil
 }
 

--- a/go/v1beta1/storage/elasticsearch_test.go
+++ b/go/v1beta1/storage/elasticsearch_test.go
@@ -506,7 +506,7 @@ var _ = Describe("elasticsearch storage", func() {
 
 		BeforeEach(func() {
 			expectedProjects = generateTestProjects(fake.Number(5, 15))
-			expectedPageSize = fake.Number(1, len(expectedProjects) - 1)
+			expectedPageSize = fake.Number(1, len(expectedProjects)-1)
 			expectedFrom = fake.Number(0, 1)
 			expectedPitId = fake.LetterN(20)
 			transport.PreparedHttpResponses = []*http.Response{
@@ -1724,7 +1724,7 @@ var _ = Describe("elasticsearch storage", func() {
 
 		BeforeEach(func() {
 			expectedOccurrences = generateTestOccurrences(fake.Number(3, 5))
-			expectedPageSize = int32(fake.Number(1, len(expectedOccurrences) - 1))
+			expectedPageSize = int32(fake.Number(1, len(expectedOccurrences)-1))
 			expectedFrom = fake.Number(0, 1)
 			expectedPitId = fake.LetterN(20)
 			transport.PreparedHttpResponses = []*http.Response{
@@ -2527,7 +2527,7 @@ var _ = Describe("elasticsearch storage", func() {
 
 		BeforeEach(func() {
 			expectedNotes = generateTestNotes(fake.Number(5, 15), expectedProjectId)
-			expectedPageSize = int32(fake.Number(1, len(expectedNotes) - 1))
+			expectedPageSize = int32(fake.Number(1, len(expectedNotes)-1))
 			expectedFrom = fake.Number(0, 1)
 			expectedPitId = fake.LetterN(20)
 			transport.PreparedHttpResponses = []*http.Response{

--- a/go/v1beta1/storage/elasticsearch_test.go
+++ b/go/v1beta1/storage/elasticsearch_test.go
@@ -505,9 +505,9 @@ var _ = Describe("elasticsearch storage", func() {
 		)
 
 		BeforeEach(func() {
-			expectedProjects = generateTestProjects(fake.Number(2, 5))
-			expectedPageSize = fake.Number(10, 100)
-			expectedFrom = fake.Number(10, 100)
+			expectedProjects = generateTestProjects(fake.Number(5, 15))
+			expectedPageSize = fake.Number(1, len(expectedProjects) - 2)
+			expectedFrom = fake.Number(1, 1)
 			expectedPitId = fake.LetterN(20)
 			transport.PreparedHttpResponses = []*http.Response{
 				{
@@ -563,6 +563,8 @@ var _ = Describe("elasticsearch storage", func() {
 				Expect(actualProjects).To(Equal(expectedProjects))
 				Expect(actualErr).ToNot(HaveOccurred())
 
+				fmt.Printf("actual next page token \"%s\"", actualNextPageToken)
+
 				pitId, from, err := esutil.ParsePageToken(actualNextPageToken)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(pitId).To(Equal(expectedPitId))
@@ -608,10 +610,27 @@ var _ = Describe("elasticsearch storage", func() {
 				Expect(actualProjects).To(Equal(expectedProjects))
 				Expect(actualErr).ToNot(HaveOccurred())
 
+
+				fmt.Printf("actual next page token \"%s\"", actualNextPageToken)
+
 				pitId, from, err := esutil.ParsePageToken(actualNextPageToken)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(pitId).To(Equal(expectedPitId))
 				Expect(from).To(BeEquivalentTo(expectedPageSize + expectedFrom))
+			})
+		})
+
+		When("getting the last page of results", func() {
+			BeforeEach(func() {
+				expectedFrom = fake.Number(len(expectedProjects), 100)
+				expectedPageToken = esutil.CreatePageToken(expectedPitId, expectedFrom)
+			})
+
+			It("should return an empty next page token", func() {
+				Expect(actualProjects).ToNot(BeNil())
+				Expect(actualProjects).To(Equal(expectedProjects))
+				Expect(actualNextPageToken).To(Equal(""))
+				Expect(actualErr).ToNot(HaveOccurred())
 			})
 		})
 
@@ -1709,9 +1728,9 @@ var _ = Describe("elasticsearch storage", func() {
 		)
 
 		BeforeEach(func() {
-			expectedOccurrences = generateTestOccurrences(fake.Number(2, 5))
-			expectedPageSize = int32(fake.Number(10, 100))
-			expectedFrom = fake.Number(10, 100)
+			expectedOccurrences = generateTestOccurrences(fake.Number(5, 15))
+			expectedPageSize = int32(fake.Number(1, len(expectedOccurrences) - 3))
+			expectedFrom = fake.Number(1, 1)
 			expectedPitId = fake.LetterN(20)
 			transport.PreparedHttpResponses = []*http.Response{
 				{
@@ -1818,6 +1837,20 @@ var _ = Describe("elasticsearch storage", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(pitId).To(Equal(expectedPitId))
 				Expect(from).To(BeEquivalentTo(int(expectedPageSize) + expectedFrom))
+			})
+		})
+
+		When("getting the last page of results", func() {
+			BeforeEach(func() {
+				expectedFrom = fake.Number(len(expectedOccurrences), 100)
+				expectedPageToken = esutil.CreatePageToken(expectedPitId, expectedFrom)
+			})
+
+			It("should return an empty next page token", func() {
+				Expect(actualOccurrences).ToNot(BeNil())
+				Expect(actualOccurrences).To(Equal(expectedOccurrences))
+				Expect(actualNextPageToken).To(Equal(""))
+				Expect(actualErr).ToNot(HaveOccurred())
 			})
 		})
 
@@ -2498,9 +2531,9 @@ var _ = Describe("elasticsearch storage", func() {
 		)
 
 		BeforeEach(func() {
-			expectedNotes = generateTestNotes(fake.Number(2, 5), expectedProjectId)
-			expectedPageSize = int32(fake.Number(10, 100))
-			expectedFrom = fake.Number(10, 100)
+			expectedNotes = generateTestNotes(fake.Number(4, 5), expectedProjectId)
+			expectedPageSize = int32(fake.Number(1, len(expectedNotes) - 1))
+			expectedFrom = fake.Number(1, 1)
 			expectedPitId = fake.LetterN(20)
 			transport.PreparedHttpResponses = []*http.Response{
 				{
@@ -2607,6 +2640,20 @@ var _ = Describe("elasticsearch storage", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(pitId).To(Equal(expectedPitId))
 				Expect(from).To(BeEquivalentTo(int(expectedPageSize) + expectedFrom))
+			})
+		})
+
+		When("getting the last page of results", func() {
+			BeforeEach(func() {
+				expectedFrom = fake.Number(len(expectedNotes), 100)
+				expectedPageToken = esutil.CreatePageToken(expectedPitId, expectedFrom)
+			})
+
+			It("should return an empty next page token", func() {
+				Expect(actualNotes).ToNot(BeNil())
+				Expect(actualNotes).To(Equal(expectedNotes))
+				Expect(actualNextPageToken).To(Equal(""))
+				Expect(actualErr).ToNot(HaveOccurred())
 			})
 		})
 

--- a/go/v1beta1/storage/elasticsearch_test.go
+++ b/go/v1beta1/storage/elasticsearch_test.go
@@ -505,7 +505,7 @@ var _ = Describe("elasticsearch storage", func() {
 		)
 
 		BeforeEach(func() {
-			expectedProjects = generateTestProjects(fake.Number(5, 15))
+			expectedProjects = generateTestProjects(fake.Number(2, 5))
 			expectedPageSize = fake.Number(5, 20)
 			expectedFrom = fake.Number(expectedPageSize, 100)
 			expectedPitId = fake.LetterN(20)
@@ -513,7 +513,7 @@ var _ = Describe("elasticsearch storage", func() {
 				{
 					StatusCode: http.StatusOK,
 					Body: createPaginatedProjectEsSearchResponse(
-						fake.Number(1000, 1000),
+						fake.Number(1000, 10000),
 						expectedProjects...,
 					),
 				},
@@ -1721,7 +1721,7 @@ var _ = Describe("elasticsearch storage", func() {
 		)
 
 		BeforeEach(func() {
-			expectedOccurrences = generateTestOccurrences(fake.Number(3, 5))
+			expectedOccurrences = generateTestOccurrences(fake.Number(2, 5))
 			expectedPageSize = int32(fake.Number(5, 20))
 			expectedFrom = fake.Number(int(expectedPageSize), 100)
 			expectedPitId = fake.LetterN(20)
@@ -2522,7 +2522,7 @@ var _ = Describe("elasticsearch storage", func() {
 		)
 
 		BeforeEach(func() {
-			expectedNotes = generateTestNotes(fake.Number(5, 15), expectedProjectId)
+			expectedNotes = generateTestNotes(fake.Number(2, 5), expectedProjectId)
 			expectedPageSize = int32(fake.Number(5, 20))
 			expectedFrom = fake.Number(int(expectedPageSize), 100)
 			expectedPitId = fake.LetterN(20)
@@ -2824,30 +2824,7 @@ func createPaginatedNoteEsSearchResponse(totalValue int, notes ...*pb.Note) io.R
 }
 
 func createGenericEsSearchResponse(messages ...proto.Message) io.ReadCloser {
-	var hits []*esutil.EsSearchResponseHit
-
-	for _, m := range messages {
-		raw, err := protojson.Marshal(proto.MessageV2(m))
-		Expect(err).ToNot(HaveOccurred())
-
-		hits = append(hits, &esutil.EsSearchResponseHit{
-			Source: raw,
-		})
-	}
-
-	response := &esutil.EsSearchResponse{
-		Took: fake.Number(1, 10),
-		Hits: &esutil.EsSearchResponseHits{
-			Total: &esutil.EsSearchResponseTotal{
-				Value: len(hits),
-			},
-			Hits: hits,
-		},
-	}
-	responseBody, err := json.Marshal(response)
-	Expect(err).ToNot(HaveOccurred())
-
-	return ioutil.NopCloser(bytes.NewReader(responseBody))
+	return createPaginatedGenericEsSearchResponse(len(messages), messages...)
 }
 
 func createPaginatedGenericEsSearchResponse(totalValue int, messages ...proto.Message) io.ReadCloser {

--- a/go/v1beta1/storage/elasticsearch_test.go
+++ b/go/v1beta1/storage/elasticsearch_test.go
@@ -614,21 +614,18 @@ var _ = Describe("elasticsearch storage", func() {
 				Expect(pitId).To(Equal(expectedPitId))
 				Expect(from).To(BeEquivalentTo(expectedPageSize + expectedFrom))
 			})
-		})
 
-		//When("getting the last page of results", func() {
-		//	BeforeEach(func() {
-		//		expectedFrom = fake.Number(len(expectedProjects), 100)
-		//		expectedPageToken = esutil.CreatePageToken(expectedPitId, expectedFrom)
-		//	})
-		//
-		//	It("should return an empty next page token", func() {
-		//		Expect(actualProjects).ToNot(BeNil())
-		//		Expect(actualProjects).To(Equal(expectedProjects))
-		//		Expect(actualNextPageToken).To(Equal(""))
-		//		Expect(actualErr).ToNot(HaveOccurred())
-		//	})
-		//})
+			When("getting the last page of results", func() {
+				BeforeEach(func() {
+					transport.PreparedHttpResponses[0].Body = createPaginatedProjectEsSearchResponse(fake.Number(1, int(expectedPageSize)) + expectedFrom - 1)
+				})
+
+				It("should return an empty next page token", func() {
+					Expect(actualNextPageToken).To(Equal(""))
+					Expect(actualErr).ToNot(HaveOccurred())
+				})
+			})
+		})
 
 		When("an invalid page token is specified (bad format)", func() {
 			BeforeEach(func() {
@@ -1836,19 +1833,16 @@ var _ = Describe("elasticsearch storage", func() {
 				Expect(from).To(BeEquivalentTo(int(expectedPageSize) + expectedFrom))
 			})
 
-			//When("getting the last page of results", func() {
-			//	BeforeEach(func() {
-			//		expectedFrom = fake.Number(len(expectedOccurrences), 100)
-			//		expectedPageToken = esutil.CreatePageToken(expectedPitId, expectedFrom)
-			//	})
-			//
-			//	It("should return an empty next page token", func() {
-			//		Expect(actualOccurrences).ToNot(BeNil())
-			//		Expect(actualOccurrences).To(Equal(expectedOccurrences))
-			//		Expect(actualNextPageToken).To(Equal(""))
-			//		Expect(actualErr).ToNot(HaveOccurred())
-			//	})
-			//})
+			When("getting the last page of results", func() {
+				BeforeEach(func() {
+					transport.PreparedHttpResponses[0].Body = createPaginatedOccurrenceEsSearchResponse(fake.Number(1, int(expectedPageSize)) + expectedFrom - 1)
+				})
+
+				It("should return an empty next page token", func() {
+					Expect(actualNextPageToken).To(Equal(""))
+					Expect(actualErr).ToNot(HaveOccurred())
+				})
+			})
 		})
 
 		When("an invalid page token is specified (bad format)", func() {
@@ -2639,21 +2633,18 @@ var _ = Describe("elasticsearch storage", func() {
 				Expect(pitId).To(Equal(expectedPitId))
 				Expect(from).To(BeEquivalentTo(int(expectedPageSize) + expectedFrom))
 			})
-		})
 
-		//When("getting the last page of results", func() {
-		//	BeforeEach(func() {
-		//		expectedFrom = fake.Number(len(expectedNotes), 100)
-		//		expectedPageToken = esutil.CreatePageToken(expectedPitId, expectedFrom)
-		//	})
-		//
-		//	It("should return an empty next page token", func() {
-		//		Expect(actualNotes).ToNot(BeNil())
-		//		Expect(actualNotes).To(Equal(expectedNotes))
-		//		Expect(actualNextPageToken).To(Equal(""))
-		//		Expect(actualErr).ToNot(HaveOccurred())
-		//	})
-		//})
+			When("getting the last page of results", func() {
+				BeforeEach(func() {
+					transport.PreparedHttpResponses[0].Body = createPaginatedNoteEsSearchResponse(fake.Number(1, int(expectedPageSize)) + expectedFrom - 1)
+				})
+
+				It("should return an empty next page token", func() {
+					Expect(actualNextPageToken).To(Equal(""))
+					Expect(actualErr).ToNot(HaveOccurred())
+				})
+			})
+		})
 
 		When("an invalid page token is specified (bad format)", func() {
 			BeforeEach(func() {
@@ -2823,7 +2814,7 @@ func createNoteEsSearchResponse(notes ...*pb.Note) io.ReadCloser {
 	return createPaginatedNoteEsSearchResponse(len(notes), notes...)
 }
 
-func createPaginatedNoteEsSearchResponse( totalValue int, notes ...*pb.Note) io.ReadCloser {
+func createPaginatedNoteEsSearchResponse(totalValue int, notes ...*pb.Note) io.ReadCloser {
 	var messages []proto.Message
 	for _, p := range notes {
 		messages = append(messages, p)

--- a/go/v1beta1/storage/elasticsearch_test.go
+++ b/go/v1beta1/storage/elasticsearch_test.go
@@ -506,13 +506,14 @@ var _ = Describe("elasticsearch storage", func() {
 
 		BeforeEach(func() {
 			expectedProjects = generateTestProjects(fake.Number(5, 15))
-			expectedPageSize = fake.Number(1, len(expectedProjects)-1)
-			expectedFrom = fake.Number(0, 1)
+			expectedPageSize = fake.Number(5, 20)
+			expectedFrom = fake.Number(expectedPageSize, 100)
 			expectedPitId = fake.LetterN(20)
 			transport.PreparedHttpResponses = []*http.Response{
 				{
 					StatusCode: http.StatusOK,
-					Body: createProjectEsSearchResponse(
+					Body: createPaginatedProjectEsSearchResponse(
+						fake.Number(1000, 1000),
 						expectedProjects...,
 					),
 				},
@@ -615,19 +616,19 @@ var _ = Describe("elasticsearch storage", func() {
 			})
 		})
 
-		When("getting the last page of results", func() {
-			BeforeEach(func() {
-				expectedFrom = fake.Number(len(expectedProjects), 100)
-				expectedPageToken = esutil.CreatePageToken(expectedPitId, expectedFrom)
-			})
-
-			It("should return an empty next page token", func() {
-				Expect(actualProjects).ToNot(BeNil())
-				Expect(actualProjects).To(Equal(expectedProjects))
-				Expect(actualNextPageToken).To(Equal(""))
-				Expect(actualErr).ToNot(HaveOccurred())
-			})
-		})
+		//When("getting the last page of results", func() {
+		//	BeforeEach(func() {
+		//		expectedFrom = fake.Number(len(expectedProjects), 100)
+		//		expectedPageToken = esutil.CreatePageToken(expectedPitId, expectedFrom)
+		//	})
+		//
+		//	It("should return an empty next page token", func() {
+		//		Expect(actualProjects).ToNot(BeNil())
+		//		Expect(actualProjects).To(Equal(expectedProjects))
+		//		Expect(actualNextPageToken).To(Equal(""))
+		//		Expect(actualErr).ToNot(HaveOccurred())
+		//	})
+		//})
 
 		When("an invalid page token is specified (bad format)", func() {
 			BeforeEach(func() {
@@ -1724,13 +1725,14 @@ var _ = Describe("elasticsearch storage", func() {
 
 		BeforeEach(func() {
 			expectedOccurrences = generateTestOccurrences(fake.Number(3, 5))
-			expectedPageSize = int32(fake.Number(1, len(expectedOccurrences)-1))
-			expectedFrom = fake.Number(0, 1)
+			expectedPageSize = int32(fake.Number(5, 20))
+			expectedFrom = fake.Number(int(expectedPageSize), 100)
 			expectedPitId = fake.LetterN(20)
 			transport.PreparedHttpResponses = []*http.Response{
 				{
 					StatusCode: http.StatusOK,
-					Body: createOccurrenceEsSearchResponse(
+					Body: createPaginatedOccurrenceEsSearchResponse(
+						fake.Number(1000, 10000),
 						expectedOccurrences...,
 					),
 				},
@@ -1833,20 +1835,20 @@ var _ = Describe("elasticsearch storage", func() {
 				Expect(pitId).To(Equal(expectedPitId))
 				Expect(from).To(BeEquivalentTo(int(expectedPageSize) + expectedFrom))
 			})
-		})
 
-		When("getting the last page of results", func() {
-			BeforeEach(func() {
-				expectedFrom = fake.Number(len(expectedOccurrences), 100)
-				expectedPageToken = esutil.CreatePageToken(expectedPitId, expectedFrom)
-			})
-
-			It("should return an empty next page token", func() {
-				Expect(actualOccurrences).ToNot(BeNil())
-				Expect(actualOccurrences).To(Equal(expectedOccurrences))
-				Expect(actualNextPageToken).To(Equal(""))
-				Expect(actualErr).ToNot(HaveOccurred())
-			})
+			//When("getting the last page of results", func() {
+			//	BeforeEach(func() {
+			//		expectedFrom = fake.Number(len(expectedOccurrences), 100)
+			//		expectedPageToken = esutil.CreatePageToken(expectedPitId, expectedFrom)
+			//	})
+			//
+			//	It("should return an empty next page token", func() {
+			//		Expect(actualOccurrences).ToNot(BeNil())
+			//		Expect(actualOccurrences).To(Equal(expectedOccurrences))
+			//		Expect(actualNextPageToken).To(Equal(""))
+			//		Expect(actualErr).ToNot(HaveOccurred())
+			//	})
+			//})
 		})
 
 		When("an invalid page token is specified (bad format)", func() {
@@ -2527,13 +2529,14 @@ var _ = Describe("elasticsearch storage", func() {
 
 		BeforeEach(func() {
 			expectedNotes = generateTestNotes(fake.Number(5, 15), expectedProjectId)
-			expectedPageSize = int32(fake.Number(1, len(expectedNotes)-1))
-			expectedFrom = fake.Number(0, 1)
+			expectedPageSize = int32(fake.Number(5, 20))
+			expectedFrom = fake.Number(int(expectedPageSize), 100)
 			expectedPitId = fake.LetterN(20)
 			transport.PreparedHttpResponses = []*http.Response{
 				{
 					StatusCode: http.StatusOK,
-					Body: createNoteEsSearchResponse(
+					Body: createPaginatedNoteEsSearchResponse(
+						fake.Number(1000, 10000),
 						expectedNotes...,
 					),
 				},
@@ -2638,19 +2641,19 @@ var _ = Describe("elasticsearch storage", func() {
 			})
 		})
 
-		When("getting the last page of results", func() {
-			BeforeEach(func() {
-				expectedFrom = fake.Number(len(expectedNotes), 100)
-				expectedPageToken = esutil.CreatePageToken(expectedPitId, expectedFrom)
-			})
-
-			It("should return an empty next page token", func() {
-				Expect(actualNotes).ToNot(BeNil())
-				Expect(actualNotes).To(Equal(expectedNotes))
-				Expect(actualNextPageToken).To(Equal(""))
-				Expect(actualErr).ToNot(HaveOccurred())
-			})
-		})
+		//When("getting the last page of results", func() {
+		//	BeforeEach(func() {
+		//		expectedFrom = fake.Number(len(expectedNotes), 100)
+		//		expectedPageToken = esutil.CreatePageToken(expectedPitId, expectedFrom)
+		//	})
+		//
+		//	It("should return an empty next page token", func() {
+		//		Expect(actualNotes).ToNot(BeNil())
+		//		Expect(actualNotes).To(Equal(expectedNotes))
+		//		Expect(actualNextPageToken).To(Equal(""))
+		//		Expect(actualErr).ToNot(HaveOccurred())
+		//	})
+		//})
 
 		When("an invalid page token is specified (bad format)", func() {
 			BeforeEach(func() {
@@ -2793,30 +2796,40 @@ var _ = Describe("elasticsearch storage", func() {
 })
 
 func createProjectEsSearchResponse(projects ...*prpb.Project) io.ReadCloser {
+	return createPaginatedProjectEsSearchResponse(len(projects), projects...)
+}
+
+func createPaginatedProjectEsSearchResponse(totalValue int, projects ...*prpb.Project) io.ReadCloser {
 	var messages []proto.Message
 	for _, p := range projects {
 		messages = append(messages, p)
 	}
 
-	return createGenericEsSearchResponse(messages...)
+	return createPaginatedGenericEsSearchResponse(totalValue, messages...)
 }
 
 func createOccurrenceEsSearchResponse(occurrences ...*pb.Occurrence) io.ReadCloser {
+	return createPaginatedOccurrenceEsSearchResponse(len(occurrences), occurrences...)
+}
+func createPaginatedOccurrenceEsSearchResponse(totalValue int, occurrences ...*pb.Occurrence) io.ReadCloser {
 	var messages []proto.Message
 	for _, p := range occurrences {
 		messages = append(messages, p)
 	}
 
-	return createGenericEsSearchResponse(messages...)
+	return createPaginatedGenericEsSearchResponse(totalValue, messages...)
+}
+func createNoteEsSearchResponse(notes ...*pb.Note) io.ReadCloser {
+	return createPaginatedNoteEsSearchResponse(len(notes), notes...)
 }
 
-func createNoteEsSearchResponse(notes ...*pb.Note) io.ReadCloser {
+func createPaginatedNoteEsSearchResponse( totalValue int, notes ...*pb.Note) io.ReadCloser {
 	var messages []proto.Message
 	for _, p := range notes {
 		messages = append(messages, p)
 	}
 
-	return createGenericEsSearchResponse(messages...)
+	return createPaginatedGenericEsSearchResponse(totalValue, messages...)
 }
 
 func createGenericEsSearchResponse(messages ...proto.Message) io.ReadCloser {
@@ -2836,6 +2849,33 @@ func createGenericEsSearchResponse(messages ...proto.Message) io.ReadCloser {
 		Hits: &esutil.EsSearchResponseHits{
 			Total: &esutil.EsSearchResponseTotal{
 				Value: len(hits),
+			},
+			Hits: hits,
+		},
+	}
+	responseBody, err := json.Marshal(response)
+	Expect(err).ToNot(HaveOccurred())
+
+	return ioutil.NopCloser(bytes.NewReader(responseBody))
+}
+
+func createPaginatedGenericEsSearchResponse(totalValue int, messages ...proto.Message) io.ReadCloser {
+	var hits []*esutil.EsSearchResponseHit
+
+	for _, m := range messages {
+		raw, err := protojson.Marshal(proto.MessageV2(m))
+		Expect(err).ToNot(HaveOccurred())
+
+		hits = append(hits, &esutil.EsSearchResponseHit{
+			Source: raw,
+		})
+	}
+
+	response := &esutil.EsSearchResponse{
+		Took: fake.Number(1, 10),
+		Hits: &esutil.EsSearchResponseHits{
+			Total: &esutil.EsSearchResponseTotal{
+				Value: totalValue,
 			},
 			Hits: hits,
 		},

--- a/go/v1beta1/storage/elasticsearch_test.go
+++ b/go/v1beta1/storage/elasticsearch_test.go
@@ -506,7 +506,7 @@ var _ = Describe("elasticsearch storage", func() {
 
 		BeforeEach(func() {
 			expectedProjects = generateTestProjects(fake.Number(5, 15))
-			expectedPageSize = fake.Number(1, 3)
+			expectedPageSize = fake.Number(1, len(expectedProjects) - 1)
 			expectedFrom = fake.Number(0, 1)
 			expectedPitId = fake.LetterN(20)
 			transport.PreparedHttpResponses = []*http.Response{
@@ -1723,8 +1723,8 @@ var _ = Describe("elasticsearch storage", func() {
 		)
 
 		BeforeEach(func() {
-			expectedOccurrences = generateTestOccurrences(fake.Number(5, 15))
-			expectedPageSize = int32(fake.Number(1, 3))
+			expectedOccurrences = generateTestOccurrences(fake.Number(3, 5))
+			expectedPageSize = int32(fake.Number(1, len(expectedOccurrences) - 1))
 			expectedFrom = fake.Number(0, 1)
 			expectedPitId = fake.LetterN(20)
 			transport.PreparedHttpResponses = []*http.Response{
@@ -2527,7 +2527,7 @@ var _ = Describe("elasticsearch storage", func() {
 
 		BeforeEach(func() {
 			expectedNotes = generateTestNotes(fake.Number(5, 15), expectedProjectId)
-			expectedPageSize = int32(fake.Number(1, 3))
+			expectedPageSize = int32(fake.Number(1, len(expectedNotes) - 1))
 			expectedFrom = fake.Number(0, 1)
 			expectedPitId = fake.LetterN(20)
 			transport.PreparedHttpResponses = []*http.Response{

--- a/go/v1beta1/storage/elasticsearch_test.go
+++ b/go/v1beta1/storage/elasticsearch_test.go
@@ -506,7 +506,7 @@ var _ = Describe("elasticsearch storage", func() {
 
 		BeforeEach(func() {
 			expectedProjects = generateTestProjects(fake.Number(5, 15))
-			expectedPageSize = fake.Number(1, len(expectedProjects) - 2)
+			expectedPageSize = fake.Number(1, len(expectedProjects)-2)
 			expectedFrom = fake.Number(1, 1)
 			expectedPitId = fake.LetterN(20)
 			transport.PreparedHttpResponses = []*http.Response{
@@ -563,8 +563,6 @@ var _ = Describe("elasticsearch storage", func() {
 				Expect(actualProjects).To(Equal(expectedProjects))
 				Expect(actualErr).ToNot(HaveOccurred())
 
-				fmt.Printf("actual next page token \"%s\"", actualNextPageToken)
-
 				pitId, from, err := esutil.ParsePageToken(actualNextPageToken)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(pitId).To(Equal(expectedPitId))
@@ -609,9 +607,6 @@ var _ = Describe("elasticsearch storage", func() {
 				Expect(actualProjects).ToNot(BeNil())
 				Expect(actualProjects).To(Equal(expectedProjects))
 				Expect(actualErr).ToNot(HaveOccurred())
-
-
-				fmt.Printf("actual next page token \"%s\"", actualNextPageToken)
 
 				pitId, from, err := esutil.ParsePageToken(actualNextPageToken)
 				Expect(err).ToNot(HaveOccurred())
@@ -1729,7 +1724,7 @@ var _ = Describe("elasticsearch storage", func() {
 
 		BeforeEach(func() {
 			expectedOccurrences = generateTestOccurrences(fake.Number(5, 15))
-			expectedPageSize = int32(fake.Number(1, len(expectedOccurrences) - 3))
+			expectedPageSize = int32(fake.Number(1, len(expectedOccurrences)-3))
 			expectedFrom = fake.Number(1, 1)
 			expectedPitId = fake.LetterN(20)
 			transport.PreparedHttpResponses = []*http.Response{
@@ -2532,7 +2527,7 @@ var _ = Describe("elasticsearch storage", func() {
 
 		BeforeEach(func() {
 			expectedNotes = generateTestNotes(fake.Number(4, 5), expectedProjectId)
-			expectedPageSize = int32(fake.Number(1, len(expectedNotes) - 1))
+			expectedPageSize = int32(fake.Number(1, len(expectedNotes)-1))
 			expectedFrom = fake.Number(1, 1)
 			expectedPitId = fake.LetterN(20)
 			transport.PreparedHttpResponses = []*http.Response{

--- a/go/v1beta1/storage/elasticsearch_test.go
+++ b/go/v1beta1/storage/elasticsearch_test.go
@@ -506,8 +506,8 @@ var _ = Describe("elasticsearch storage", func() {
 
 		BeforeEach(func() {
 			expectedProjects = generateTestProjects(fake.Number(5, 15))
-			expectedPageSize = fake.Number(1, len(expectedProjects)-2)
-			expectedFrom = fake.Number(1, 1)
+			expectedPageSize = fake.Number(1, 3)
+			expectedFrom = fake.Number(0, 1)
 			expectedPitId = fake.LetterN(20)
 			transport.PreparedHttpResponses = []*http.Response{
 				{
@@ -1724,8 +1724,8 @@ var _ = Describe("elasticsearch storage", func() {
 
 		BeforeEach(func() {
 			expectedOccurrences = generateTestOccurrences(fake.Number(5, 15))
-			expectedPageSize = int32(fake.Number(1, len(expectedOccurrences)-3))
-			expectedFrom = fake.Number(1, 1)
+			expectedPageSize = int32(fake.Number(1, 3))
+			expectedFrom = fake.Number(0, 1)
 			expectedPitId = fake.LetterN(20)
 			transport.PreparedHttpResponses = []*http.Response{
 				{
@@ -2526,9 +2526,9 @@ var _ = Describe("elasticsearch storage", func() {
 		)
 
 		BeforeEach(func() {
-			expectedNotes = generateTestNotes(fake.Number(4, 5), expectedProjectId)
-			expectedPageSize = int32(fake.Number(1, len(expectedNotes)-1))
-			expectedFrom = fake.Number(1, 1)
+			expectedNotes = generateTestNotes(fake.Number(5, 15), expectedProjectId)
+			expectedPageSize = int32(fake.Number(1, 3))
+			expectedFrom = fake.Number(0, 1)
 			expectedPitId = fake.LetterN(20)
 			transport.PreparedHttpResponses = []*http.Response{
 				{


### PR DESCRIPTION
Closes #66 

Also ups the PIT TTL to 5 minutes so anyone searching won't unexpectedly lose their spot in search unless they're really hanging out there.

[related rode PR](https://github.com/rode/rode/pull/60)