### PR TITLE
Fix flaky integration test

### DIFF
--- a/test/v1beta1/note_test.go
+++ b/test/v1beta1/note_test.go
@@ -257,7 +257,14 @@ func TestNote(t *testing.T) {
 
 				Expect(err).ToNot(HaveOccurred())
 				Expect(res.Notes).To(HaveLen(pageSize))
-				Expect(res.NextPageToken).ToNot(BeEmpty())
+
+				isLastPage := len(res.Notes) + len(foundNotes) == len(batch.Notes)
+				if isLastPage {
+					Expect(res.NextPageToken).To(BeEmpty())
+				} else {
+					Expect(res.NextPageToken).ToNot(BeEmpty())
+				}
+
 
 				// ensure we have not received these notes already
 				for _, o := range res.Notes {

--- a/test/v1beta1/note_test.go
+++ b/test/v1beta1/note_test.go
@@ -258,13 +258,12 @@ func TestNote(t *testing.T) {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(res.Notes).To(HaveLen(pageSize))
 
-				isLastPage := len(res.Notes) + len(foundNotes) == len(batch.Notes)
+				isLastPage := len(res.Notes)+len(foundNotes) == len(batch.Notes)
 				if isLastPage {
 					Expect(res.NextPageToken).To(BeEmpty())
 				} else {
 					Expect(res.NextPageToken).ToNot(BeEmpty())
 				}
-
 
 				// ensure we have not received these notes already
 				for _, o := range res.Notes {


### PR DESCRIPTION
I think I lost the workflow history, but the first time this [ran](https://github.com/rode/grafeas-elasticsearch/pull/74/checks?check_run_id=2461949606) it failed the note pagination tests. I kicked it off again and it went green. 

Similar story with this [run](https://github.com/rode/grafeas-elasticsearch/runs/2413454376), the next commit didn't change anything related to the code or integration tests but it passed. 