### PR TITLE
[filtering] add "has_parent" query field

### DIFF
--- a/go/v1beta1/storage/filtering/types.go
+++ b/go/v1beta1/storage/filtering/types.go
@@ -22,6 +22,7 @@ type Query struct {
 	QueryString *QueryString `json:"query_string,omitempty"`
 	Nested      *Nested      `json:"nested,omitempty"`
 	Range       *Range       `json:"range,omitempty"`
+	HasParent   *HasParent   `json:"has_parent,omitempty"`
 }
 
 // Bool holds a general query that carries any number of
@@ -57,6 +58,12 @@ type Nested struct {
 
 // Holds an operator that evaluates a range for comparisons
 type Range map[string]*RangeOperator
+
+// HasParent is used to query for resources that use a join field and have a parent resource
+type HasParent struct {
+	ParentType string `json:"parent_type"`
+	Query      *Query `json:"query"`
+}
 
 type RangeOperator struct {
 	Greater       string `json:"gt,omitempty"`


### PR DESCRIPTION
this is needed to effectively query for documents that have a specific parent.  this change is a bit weird since the filtering package doesn't use this new type in any way, but it's where all of the other query types live so I thought this was fine for now.