### PR TITLE
[esutil.Client] Consistently escape document id

### DIFF
--- a/go/v1beta1/storage/esutil/client.go
+++ b/go/v1beta1/storage/esutil/client.go
@@ -430,7 +430,7 @@ func (c *client) Get(ctx context.Context, request *GetRequest) (*EsGetResponse, 
 	}
 
 	if request.Routing != "" {
-		getOpts = append(getOpts, c.esClient.Get.WithRouting(url.QueryEscape(request.Routing)))
+		getOpts = append(getOpts, c.esClient.Get.WithRouting(request.Routing))
 	}
 
 	res, err := c.esClient.Get(

--- a/go/v1beta1/storage/esutil/client.go
+++ b/go/v1beta1/storage/esutil/client.go
@@ -149,7 +149,7 @@ func (c *client) Create(ctx context.Context, request *CreateRequest) (string, er
 		c.esClient.Index.WithRefresh(request.Refresh),
 	}
 	if request.DocumentId != "" {
-		indexOpts = append(indexOpts, c.esClient.Index.WithDocumentID(request.DocumentId))
+		indexOpts = append(indexOpts, c.esClient.Index.WithDocumentID(url.QueryEscape(request.DocumentId)))
 	}
 
 	var (

--- a/go/v1beta1/storage/esutil/client.go
+++ b/go/v1beta1/storage/esutil/client.go
@@ -497,7 +497,7 @@ func (c *client) Update(ctx context.Context, request *UpdateRequest) (*EsIndexDo
 	}
 
 	indexOpts := []func(*esapi.IndexRequest){
-		c.esClient.Index.WithDocumentID(request.DocumentId),
+		c.esClient.Index.WithDocumentID(url.QueryEscape(request.DocumentId)),
 		c.esClient.Index.WithContext(ctx),
 		c.esClient.Index.WithRefresh(request.Refresh),
 	}

--- a/go/v1beta1/storage/esutil/client.go
+++ b/go/v1beta1/storage/esutil/client.go
@@ -168,7 +168,7 @@ func (c *client) Create(ctx context.Context, request *CreateRequest) (string, er
 		}
 
 		if request.Join.Parent != "" {
-			indexOpts = append(indexOpts, c.esClient.Index.WithRouting(url.QueryEscape(request.Join.Parent)))
+			indexOpts = append(indexOpts, c.esClient.Index.WithRouting(request.Join.Parent))
 		}
 	} else {
 		doc, err = protojson.MarshalOptions{EmitUnpopulated: true}.Marshal(request.Message)

--- a/go/v1beta1/storage/esutil/client.go
+++ b/go/v1beta1/storage/esutil/client.go
@@ -457,10 +457,21 @@ func (c *client) Get(ctx context.Context, request *GetRequest) (*EsGetResponse, 
 
 func (c *client) MultiGet(ctx context.Context, request *MultiGetRequest) (*EsMultiGetResponse, error) {
 	log := c.logger.Named("MultiGet")
-	encodedBody, requestJson := EncodeRequest(&EsMultiGetRequest{
+
+	esRequest := &EsMultiGetRequest{
 		IDs:  request.DocumentIds,
 		Docs: request.Items,
-	})
+	}
+
+	for i, id := range esRequest.IDs {
+		esRequest.IDs[i] = url.QueryEscape(id)
+	}
+
+	for i, item := range esRequest.Docs {
+		esRequest.Docs[i].Id = url.QueryEscape(item.Id)
+	}
+
+	encodedBody, requestJson := EncodeRequest(esRequest)
 	log = log.With(zap.String("request", requestJson))
 
 	res, err := c.esClient.Mget(

--- a/go/v1beta1/storage/esutil/client.go
+++ b/go/v1beta1/storage/esutil/client.go
@@ -212,7 +212,7 @@ func (c *client) Bulk(ctx context.Context, request *BulkRequest) (*EsBulkRespons
 		metadata := &EsBulkQueryFragment{}
 
 		operationFragment := &EsBulkQueryOperationFragment{
-			Id:    item.DocumentId,
+			Id:    url.QueryEscape(item.DocumentId),
 			Index: request.Index,
 		}
 		if item.Operation == BULK_CREATE {

--- a/go/v1beta1/storage/esutil/client.go
+++ b/go/v1beta1/storage/esutil/client.go
@@ -111,7 +111,7 @@ type DeleteRequest struct {
 }
 
 const defaultPitKeepAlive = "5m"
-const grafeasMaxPageSize = 1000
+const maxPageSize = 1000
 
 //counterfeiter:generate . Client
 type Client interface {
@@ -349,7 +349,7 @@ func (c *client) Search(ctx context.Context, request *SearchRequest) (*SearchRes
 	} else {
 		searchOptions = append(searchOptions,
 			c.esClient.Search.WithIndex(request.Index),
-			c.esClient.Search.WithSize(grafeasMaxPageSize),
+			c.esClient.Search.WithSize(maxPageSize),
 		)
 	}
 

--- a/go/v1beta1/storage/esutil/client_test.go
+++ b/go/v1beta1/storage/esutil/client_test.go
@@ -1285,7 +1285,7 @@ func createRandomSearches(l int) []*EsSearch {
 func createRandomDocumentIds(l int) []string {
 	var result []string
 	for i := 0; i < l; i++ {
-		result = append(result, fake.URL())
+		result = append(result, fake.LetterN(10))
 	}
 
 	return result

--- a/go/v1beta1/storage/esutil/client_test.go
+++ b/go/v1beta1/storage/esutil/client_test.go
@@ -1076,6 +1076,17 @@ var _ = Describe("elasticsearch client", func() {
 			Expect(actualErr).ToNot(HaveOccurred())
 		})
 
+		When("the document id contains url-unsafe characters", func() {
+			BeforeEach(func() {
+				expectedDocumentId = fake.URL()
+				expectedUpdateRequest.DocumentId = expectedDocumentId
+			})
+
+			It("should query escape the document id", func() {
+				Expect(transport.ReceivedHttpRequests[0].URL.RawPath).To(ContainSubstring(url.QueryEscape(expectedDocumentId)))
+			})
+		})
+
 		When("indexing the document fails", func() {
 			BeforeEach(func() {
 				transport.PreparedHttpResponses[0] = &http.Response{

--- a/go/v1beta1/storage/esutil/client_test.go
+++ b/go/v1beta1/storage/esutil/client_test.go
@@ -122,6 +122,17 @@ var _ = Describe("elasticsearch client", func() {
 			It("should index the document using the provided ID", func() {
 				Expect(transport.ReceivedHttpRequests[0].URL.Path).To(Equal(fmt.Sprintf("/%s/_doc/%s", expectedCreateRequest.Index, expectedCreateRequest.DocumentId)))
 			})
+
+			When("the document id contains url-unsafe characters", func() {
+				BeforeEach(func() {
+					expectedDocumentId = fake.URL()
+					expectedCreateRequest.DocumentId = expectedDocumentId
+				})
+
+				It("should query escape the document id", func() {
+					Expect(transport.ReceivedHttpRequests[0].URL.RawPath).To(ContainSubstring(url.QueryEscape(expectedDocumentId)))
+				})
+			})
 		})
 
 		When("indexing the document fails", func() {

--- a/go/v1beta1/storage/esutil/client_test.go
+++ b/go/v1beta1/storage/esutil/client_test.go
@@ -371,7 +371,35 @@ var _ = Describe("elasticsearch client", func() {
 			})
 		})
 
-		When("one of the item specifies a join and a routing value", func() {
+		When("one of the items has a document id with non-url safe characters", func() {
+			var (
+				expectedDocumentId string
+				randomItemIndex int
+			)
+
+			BeforeEach(func() {
+				expectedDocumentId = fake.URL()
+				randomItemIndex = fake.Number(0, len(expectedBulkItems)-1)
+				expectedBulkItems[randomItemIndex].DocumentId = expectedDocumentId
+			})
+
+			FIt("should query escape the document id", func() {
+				var expectedPayloads []interface{}
+
+				for i := 0; i < len(expectedOccurrences); i++ {
+					expectedPayloads = append(expectedPayloads, &EsBulkQueryFragment{}, &pb.Occurrence{})
+				}
+
+				parseNDJSONRequestBodyWithProtobufs(transport.ReceivedHttpRequests[0].Body, expectedPayloads)
+
+				metadataIndex := randomItemIndex * 2
+				metadata := expectedPayloads[metadataIndex].(*EsBulkQueryFragment)
+
+				Expect(metadata.Index.Id).To(Equal(url.QueryEscape(expectedDocumentId)))
+			})
+		})
+
+		When("one of the item specifi", func() {
 			BeforeEach(func() {
 				randomItemIndex := fake.Number(0, len(expectedBulkItems)-1)
 				expectedBulkItems[randomItemIndex].Routing = fake.UUID()

--- a/go/v1beta1/storage/esutil/client_test.go
+++ b/go/v1beta1/storage/esutil/client_test.go
@@ -516,7 +516,7 @@ var _ = Describe("elasticsearch client", func() {
 		It("should send a search request to ES", func() {
 			Expect(transport.ReceivedHttpRequests[0].URL.Path).To(Equal(fmt.Sprintf("/%s/_search", expectedIndex)))
 			// page size should be 1000 by default
-			Expect(transport.ReceivedHttpRequests[0].URL.Query().Get("size")).To(Equal(strconv.Itoa(grafeasMaxPageSize)))
+			Expect(transport.ReceivedHttpRequests[0].URL.Query().Get("size")).To(Equal(strconv.Itoa(maxPageSize)))
 
 			searchRequest := &EsSearch{}
 			ReadRequestBody(transport.ReceivedHttpRequests[0], &searchRequest)


### PR DESCRIPTION
Currently the client was escaping the document id on `Get`, but not `Create`, or `Update`. This was causing documents to be created that couldn't be retrieved by passing the same id to the client. 

I also removed the query escaping around the routing value -- it appears that the [Elasticsearch client already handles that](https://github.com/elastic/go-elasticsearch/blob/959da155ffb25ef428bcc7e417adb40e9aa973c0/esapi/api.index.go#L170), so it was being double-encoded (I don't this affected anything since none of the routing values we use need escaping at the moment). 