### PR TITLE
[esutil.Client] Expose generic multiget

### DIFF
--- a/go/v1beta1/storage/esutil/client.go
+++ b/go/v1beta1/storage/esutil/client.go
@@ -464,10 +464,17 @@ func (c *client) MultiGet(ctx context.Context, request *MultiGetRequest) (*EsMul
 	})
 	log = log.With(zap.String("request", requestJson))
 
+	mgetOpts := []func(mgetRequest *esapi.MgetRequest){
+		c.esClient.Mget.WithContext(ctx),
+	}
+
+	if request.Index != "" {
+		mgetOpts = append(mgetOpts, c.esClient.Mget.WithIndex(request.Index))
+	}
+
 	res, err := c.esClient.Mget(
 		encodedBody,
-		c.esClient.Mget.WithContext(ctx),
-		c.esClient.Mget.WithIndex(request.Index),
+		mgetOpts...,
 	)
 	if err != nil {
 		return nil, err

--- a/go/v1beta1/storage/esutil/client_test.go
+++ b/go/v1beta1/storage/esutil/client_test.go
@@ -1000,6 +1000,17 @@ var _ = Describe("elasticsearch client", func() {
 			})
 		})
 
+		When("no index is specified", func() {
+			BeforeEach(func() {
+				expectedMultiGetRequest.Index = ""
+			})
+
+			It("should use the generic mget path", func() {
+				Expect(transport.ReceivedHttpRequests[0].Method).To(Equal(http.MethodGet))
+				Expect(transport.ReceivedHttpRequests[0].URL.Path).To(Equal("/_mget"))
+			})
+		})
+
 		When("the multiget operation fails", func() {
 			BeforeEach(func() {
 				transport.PreparedHttpResponses = []*http.Response{

--- a/go/v1beta1/storage/esutil/types.go
+++ b/go/v1beta1/storage/esutil/types.go
@@ -161,6 +161,7 @@ type ESPitResponse struct {
 
 type EsMultiGetItem struct {
 	Id      string `json:"_id"`
+	Index   string `json:"_index,omitempty"`
 	Routing string `json:"routing,omitempty"`
 }
 


### PR DESCRIPTION
Using this for policy assignments in Rode in order to check that the target policy group and policy version exist. 