### PR TITLE
Bump es-index-manager

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/onsi/ginkgo v1.16.2
 	github.com/onsi/gomega v1.12.0
 	github.com/pelletier/go-toml v1.7.0 // indirect
-	github.com/rode/es-index-manager v0.1.1
+	github.com/rode/es-index-manager v0.2.2
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/spf13/viper v1.7.0 // indirect
 	github.com/stretchr/testify v1.6.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -227,8 +227,8 @@ github.com/prometheus/common v0.4.0/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y8
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
-github.com/rode/es-index-manager v0.1.1 h1:dNHTEBBzAxyU+RrAlhTB9xuY2yDMStZcMd8ACwBUYAY=
-github.com/rode/es-index-manager v0.1.1/go.mod h1:QsnfBo0VUWWfOkXUHUdiWSiJghajbVwHjCA+OMqO0E8=
+github.com/rode/es-index-manager v0.2.2 h1:rhJBE6//OHnH9HIxmukgrrh4NVNm7T4XkC016umX2qM=
+github.com/rode/es-index-manager v0.2.2/go.mod h1:QsnfBo0VUWWfOkXUHUdiWSiJghajbVwHjCA+OMqO0E8=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rs/cors v1.7.0 h1:+88SsELBHx5r+hZ8TCkggzSstaWNbDvThkVK8H6f9ik=


### PR DESCRIPTION
Brings in https://github.com/rode/es-index-manager/pull/11, so that we don't crash when an index appears to belong to Rode but doesn't have a mapping. 
